### PR TITLE
docs: publicar la documentacion como sitio con MkDocs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,72 @@
+name: Documentación
+
+# Construye el sitio de documentación con MkDocs y lo publica en GitHub Pages.
+# En Pull Request solo construye: sirve de verificación de que la documentación
+# sigue siendo válida (enlaces, navegación, sintaxis) antes de integrar.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    paths:
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  construir:
+    name: Construir el sitio
+    runs-on: ubuntu-latest
+    steps:
+      - name: Obtener el código
+        uses: actions/checkout@v4
+
+      - name: Preparar Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
+
+      - name: Instalar dependencias
+        run: pip install -r requirements-docs.txt
+
+      # --strict convierte cualquier advertencia en error: un enlace roto o un
+      # documento fuera de la navegación detiene el pipeline.
+      - name: Construir la documentación
+        run: mkdocs build --strict
+
+      - name: Publicar el artefacto
+        if: github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+
+  desplegar:
+    name: Desplegar en GitHub Pages
+    if: github.ref == 'refs/heads/main'
+    needs: construir
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.despliegue.outputs.page_url }}
+    steps:
+      - name: Desplegar
+        id: despliegue
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,39 @@
+# Artefactos de construcción y archivos locales del entorno de desarrollo.
+# Art. XI.5: no se versionan artefactos generados ni dependencias instaladas.
+
+# --- Maven / Java ---
+target/
+*.class
+*.log
+.mvn/timing.properties
+.mvn/wrapper/maven-wrapper.properties.bak
+
+# --- MkDocs ---
+site/
+.cache/
+__pycache__/
+*.py[cod]
+.venv/
+venv/
+
+# --- Configuración de entorno ---
+# .env.example SÍ se versiona; .env con valores reales, nunca (Art. IV.3).
+.env
+.env.*
+!.env.example
+
+# --- IDE ---
+.idea/
+*.iml
+*.ipr
+*.iws
+.vscode/
+.settings/
+.classpath
+.project
+*.swp
+
+# --- Sistema operativo ---
+.DS_Store
+Thumbs.db
+desktop.ini

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `development-guide.md` |
-| Versión | 0.1.0 |
+| Versión | 0.2.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
@@ -65,9 +65,37 @@ mvn test                      # pruebas unitarias
 mvn verify                    # todo, incluidas pruebas de integración
 mvn flyway:info               # estado de las migraciones
 docker compose down -v        # reinicia la base de datos desde cero
+mkdocs serve                  # sitio de documentación en local (ver 2.5)
 ```
 
 Si `mvn verify` falla en tu máquina, **no** abras el Pull Request esperando que CI lo resuelva.
+
+### 2.5 La documentación como sitio
+
+La documentación de `docs/` se publica como sitio navegable con MkDocs y el tema Material. Los archivos Markdown siguen siendo la **fuente de verdad**; el sitio es solo una vista de ellos.
+
+**Con Docker, sin instalar nada** (recomendado, y coherente con el Art. X.1):
+
+```bash
+docker run --rm -it -p 8000:8000 -v "$PWD":/docs squidfunk/mkdocs-material
+```
+
+**Con Python**, si prefieres tenerlo local:
+
+```bash
+pip install -r requirements-docs.txt
+mkdocs serve            # recarga en caliente en http://localhost:8000
+mkdocs build --strict   # construye en site/ y falla ante cualquier advertencia
+```
+
+Reglas al tocar la documentación:
+
+- Todo documento nuevo **DEBE** agregarse a `nav` en `mkdocs.yml`. Con `--strict`, un documento fuera de la navegación o un enlace roto **detiene el pipeline**.
+- Los enlaces entre documentos se escriben como rutas relativas al archivo `.md` (`[Seguridad](security.md)`), no como URLs del sitio publicado. Así funcionan igual en GitHub, en el editor y en el sitio.
+- Los diagramas se escriben en bloques ` ```mermaid `, que se renderizan tanto en GitHub como en el sitio.
+- El directorio `site/` es un artefacto de construcción y no se versiona (Art. XI.5).
+
+El sitio se publica automáticamente en GitHub Pages al integrar en `main`. En Pull Request solo se construye, como verificación de que la documentación sigue siendo válida.
 
 ---
 
@@ -430,3 +458,4 @@ Aplica el Artículo XIII. En términos prácticos:
 | Versión | Fecha | Cambio | Responsable |
 |---|---|---|---|
 | 0.1.0 | 19-08-2026 | Creación inicial. | Responsable técnico |
+| 0.2.0 | 19-08-2026 | Nueva sección 2.5: publicación de la documentación como sitio con MkDocs. | Responsable técnico |

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,106 @@
+# Documentación técnica de NEXUS
+
+Backend de la plataforma NEXUS — **FACTECH GROUP SAS**.
+
+Esta documentación es parte del repositorio y se versiona junto al código (Art. XII.1). Si un cambio altera comportamiento, contrato o esquema, la documentación afectada se actualiza **en el mismo Pull Request**.
+
+---
+
+## Documentos
+
+<div class="grid cards" markdown>
+
+-   :material-gavel:{ .lg .middle } **Constitución**
+
+    ---
+
+    Los principios no negociables del proyecto. 15 artículos con reglas verificables, jerarquía documental, definición de terminado y proceso de enmienda.
+
+    [:octicons-arrow-right-24: Leer la constitución](constitution.md)
+
+-   :material-sitemap:{ .lg .middle } **Arquitectura**
+
+    ---
+
+    Componentes, stack, estructura del código, convenciones de esquema y de API, flujo de una petición y observabilidad.
+
+    [:octicons-arrow-right-24: Ver la arquitectura](architecture.md)
+
+-   :material-shield-lock:{ .lg .middle } **Seguridad**
+
+    ---
+
+    Quién es quién y qué puede hacer cada quien: identidad, autorización por contención de privilegios, autenticación y protección de datos.
+
+    [:octicons-arrow-right-24: Ver el modelo de seguridad](security.md)
+
+-   :material-code-braces:{ .lg .middle } **Guía de desarrollo**
+
+    ---
+
+    Cómo se escribe código aquí, día a día: entorno local, convenciones, manejo de errores, transacciones, Git y checklist previo al Pull Request.
+
+    [:octicons-arrow-right-24: Abrir la guía](development-guide.md)
+
+</div>
+
+---
+
+## Jerarquía normativa
+
+En caso de conflicto, prevalece el documento de mayor jerarquía. Ningún elemento de nivel inferior puede contradecir a uno superior.
+
+```mermaid
+graph TD
+    C["<b>Constitución</b><br/>principios no negociables"]
+    M["<b>Documento Marco</b><br/>estándares y metodología"]
+    E["<b>Especificación del módulo</b><br/>comportamiento esperado"]
+    A["<b>Decisiones de arquitectura</b><br/>decisiones técnicas registradas"]
+    I["<b>Implementación</b><br/>el código"]
+    C --> M --> E --> A --> I
+```
+
+Si la implementación necesita contradecir una regla constitucional, **primero se enmienda la constitución**, nunca al revés.
+
+---
+
+## Metodología
+
+El proyecto sigue **Spec-Driven Development**: la especificación es la fuente de verdad y precede a la implementación.
+
+```
+Requerimiento → Especificación → Issue → Pull Request → Código → Prueba → Resultado
+```
+
+Toda funcionalidad cuenta con una especificación aprobada antes de que se escriba su primera línea de código (Art. I.1), y todo cambio es reconstruible hasta el requerimiento que lo originó (Art. III.1).
+
+---
+
+## Estado del proyecto
+
+!!! warning "Documentación en estado Borrador"
+
+    Todos los documentos están en versiones `0.x`. Mientras permanezcan en Borrador, las enmiendas se acumulan como MINOR; la versión `1.0.0` se emite al ser aprobada por el stakeholder (Art. 17.6).
+
+| Documento | Versión | Estado |
+|---|---|---|
+| [Constitución](constitution.md) | 0.3.0 | Borrador |
+| [Arquitectura](architecture.md) | 0.3.0 | Borrador |
+| [Seguridad](security.md) | 0.2.0 | Borrador |
+| [Guía de desarrollo](development-guide.md) | 0.2.0 | Borrador |
+| Estrategia de pruebas | — | Pendiente |
+| Requerimientos y trazabilidad | — | Pendiente |
+
+### Decisiones
+
+**Cerradas:** PostgreSQL como único motor · claves `uuid` v7 · Java 21 LTS con Spring Boot 3 y Maven · migraciones Flyway · auditoría separada en `audit_log` y `request_log` · umbrales p95 de rendimiento · repositorios separados con contrato OpenAPI · autenticación JWT con refresh revocable · contención de privilegios entre roles · permisos `recurso:acción` · Argon2id.
+
+**Pendientes:** infraestructura de despliegue · retención de registros · política de idempotencia · parámetros concretos de seguridad · catálogo inicial de permisos · restablecimiento de contraseña · identidad para procesos automáticos.
+
+---
+
+## Sobre este sitio
+
+Se genera con [MkDocs](https://www.mkdocs.org/) y el tema [Material](https://squidfunk.github.io/mkdocs-material/) a partir de los archivos Markdown de `docs/`. La fuente de verdad son esos archivos, no el sitio publicado: cualquier corrección se hace sobre el Markdown y se integra por Pull Request.
+
+Para levantarlo en local, ver la [guía de desarrollo](development-guide.md#25-la-documentacion-como-sitio).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,83 @@
+site_name: NEXUS — Documentación técnica
+site_description: Documentación técnica del backend de NEXUS — FACTECH GROUP SAS
+site_author: FACTECH GROUP SAS
+copyright: FACTECH GROUP SAS
+
+repo_url: https://github.com/NexusPro-Dev/backend
+repo_name: NexusPro-Dev/backend
+edit_uri: edit/develop/docs/
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: es
+  icon:
+    repo: fontawesome/brands/github
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.top
+    - navigation.indexes
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - content.code.copy
+    - content.action.edit
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Cambiar a modo oscuro
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: blue grey
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Cambiar a modo claro
+
+plugins:
+  - search:
+      lang: es
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      permalink_title: Enlace a esta sección
+  - pymdownx.details
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
+
+nav:
+  - Inicio: index.md
+  - Constitución: constitution.md
+  - Arquitectura: architecture.md
+  - Seguridad: security.md
+  - Guía de desarrollo: development-guide.md
+
+# Al agregar un documento nuevo, incorporarlo a la navegación anterior.
+# La construccion se ejecuta con --strict: un enlace roto detiene el pipeline.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,0 +1,10 @@
+# Dependencias para construir el sitio de documentacion (MkDocs).
+# No forman parte del artefacto de la aplicacion: son exclusivamente
+# herramientas de documentacion.
+#
+# Versiones fijadas de forma explicita (Art. X.3).
+# Uso:  pip install -r requirements-docs.txt
+
+mkdocs~=1.6
+mkdocs-material~=9.5
+pymdown-extensions~=10.11


### PR DESCRIPTION
La documentacion en Markdown se lee bien en GitHub pero no ofrece buscador, navegacion ni una entrada unica. MkDocs con el tema Material la publica como sitio navegable sin cambiar la fuente de verdad: los .md de docs/ siguen siendo el original y el sitio es solo una vista de ellos.

Agrega:

- mkdocs.yml: tema Material en espanol, modo claro/oscuro, buscador y renderizado de mermaid via pymdownx.superfences. Los diagramas de architecture.md y security.md ya se dibujan sin cambios.
- docs/index.md: portada con los cuatro documentos, la jerarquia normativa, el flujo SDD y el estado de versiones y decisiones.
- requirements-docs.txt: dependencias fijadas (Art. X.3). El rango mkdocs~=1.6 excluye deliberadamente MkDocs 2.0, que segun el equipo de Material rompe el sistema de plugins y de temas sin ruta de migracion.
- .github/workflows/docs.yml: construye en cada Pull Request y despliega en GitHub Pages al integrar en main. Usa mkdocs build --strict, de modo que un enlace roto o un documento fuera de la navegacion detiene el pipeline.
- .gitignore: primer .gitignore del repositorio. Cubre target/, site/, .env y archivos de IDE (Art. XI.5). .env.example queda excluido de la exclusion.
- development-guide.md v0.2.0: nueva seccion 2.5 con cómo levantar el sitio en local, con Docker o con Python, y las reglas al tocar documentacion.

Verificado con mkdocs build --strict sobre la imagen squidfunk/mkdocs-material: construye sin advertencias y genera las cinco paginas.

Nota: GitHub Pages debe habilitarse una vez en Settings > Pages, con origen "GitHub Actions", para que el despliegue funcione.