### PR TITLE
docs: separar la auditoria en cuatro registros especializados

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -98,7 +98,7 @@ src/main/java/com/factech/nexus/
 │   ├── error/                  Manejo global de errores y formato de respuesta
 │   ├── security/               Filtros de autenticación y autorización
 │   ├── observability/          Correlación, request_log, logging estructurado
-│   ├── audit/                  Registro de eventos de negocio (audit_log)
+│   ├── audit/                  Los cuatro registros de auditoría (§6.6)
 │   └── persistence/            Tipos base, generación de UUID v7, auditoría de entidades
 │
 └── modules/
@@ -170,16 +170,177 @@ Toda tabla de negocio incluye (Art. V.7):
 
 Las marcas de tiempo se almacenan siempre en `timestamptz` en UTC. La conversión a zona horaria local es responsabilidad del frontend.
 
-**Las tablas no almacenan el actor del cambio** (Art. V.7). Quién creó o modificó un registro se responde consultando `audit_log` por entidad e identificador, que es su única fuente de verdad. Replicar el actor en cada tabla duplicaría un dato que ya existe y que puede quedar desincronizado.
+**Las tablas no almacenan el actor del cambio** (Art. V.7). Quién creó o modificó un registro se responde consultando `audit_change_log` por entidad e identificador; quién lo eliminó y por qué, `audit_deletion_log` (§6.6). Esos registros son la única fuente de verdad del actor. Replicar el actor en cada tabla duplicaría un dato que ya existe y que puede quedar desincronizado.
 
 Dos consecuencias que deben asumirse de forma consciente:
 
 1. **Toda operación de escritura DEBE emitir su evento de auditoría.** Es lo que sostiene el modelo: si una operación omite el evento, la autoría de ese cambio se pierde y no hay forma de reconstruirla (Art. V.8).
-2. **Mostrar "creado por" en una vista exige consultar `audit_log`.** Para listados, esa consulta se resuelve con una proyección específica sobre el registro de auditoría, no agregando la columna de vuelta a la tabla de negocio.
+2. **Mostrar "creado por" en una vista exige consultar la auditoría.** Para listados, esa consulta se resuelve con una proyección específica sobre `audit_change_log`, no agregando la columna de vuelta a la tabla de negocio.
 
 ### 6.5 Integridad
 
 La integridad se declara en el esquema, no solo en la aplicación (Art. V.6): claves foráneas, `NOT NULL`, restricciones únicas y `CHECK` para dominios cerrados. Una validación en Java **complementa** la restricción de base de datos; no la sustituye.
+
+### 6.6 Registros de auditoría
+
+Implementa el Art. V.8. Son **cuatro tablas, no una**. Cada una responde una pregunta que las demás no pueden responder, y cada una declara `NOT NULL` lo que en su contexto es obligatorio — algo que un registro único no permite, porque lo obligatorio de un caso es inaplicable en otro.
+
+| Tabla | Responde | Se escribe cuando |
+|---|---|---|
+| `audit_change_log` | Quién creó qué, y quién editó qué | Un alta o una edición se confirma |
+| `audit_deletion_log` | Quién eliminó qué, y **por qué** | Una baja lógica o física se confirma |
+| `audit_error_log` | A quién le falló qué, sobre qué recurso | Un fallo no controlado o un rechazo por regla de negocio |
+| `audit_security_log` | Quién intentó qué contra el control de acceso | Los eventos de `security.md` §8 |
+
+#### 6.6.1 Núcleo común
+
+Las cuatro comparten estas columnas. Es lo que permite consultarlas en conjunto y correlacionarlas con `request_log`:
+
+| Columna | Tipo | Descripción |
+|---|---|---|
+| `id` | `uuid` | Clave primaria, UUID v7 |
+| `occurred_at` | `timestamptz` | Momento del evento, en UTC |
+| `actor_id` | `uuid` NULL | Usuario responsable. `NULL` = anónimo o proceso del sistema |
+| `correlation_id` | `uuid` NULL | Enlace con `request_log` (Art. XV.1) |
+| `ip_address` | `inet` NULL | Dirección de origen (Art. V.15) |
+| `user_agent` | `text` NULL | Cliente desde el que se originó la operación |
+
+`inet` es el tipo nativo de PostgreSQL para direcciones: valida el formato, admite IPv4 e IPv6 sin decidir longitudes, y permite consultar por rango de red con el operador de contención de subred — sobre un `varchar` esa misma consulta obliga a recorrer la tabla entera.
+
+Las tres columnas de origen son nulables **a la vez y por la misma razón**: existen operaciones sin petición HTTP detrás (migraciones, tareas programadas, procesos internos). Esa correspondencia la fija el esquema, no la aplicación:
+
+```sql
+CONSTRAINT ck_audit_origen CHECK (
+    (correlation_id IS NULL     AND ip_address IS NULL)
+ OR (correlation_id IS NOT NULL AND ip_address IS NOT NULL)
+)
+```
+
+Con esa restricción, una fila sin IP significa inequívocamente «no vino de la red», y nunca «se olvidó registrarla» (Art. V.15).
+
+**Obtención de la IP.** Detrás de un proxy inverso, la IP del socket es la del proxy; la real llega en `X-Forwarded-For`, que es una cabecera **provista por el cliente** y por tanto falsificable. Se resuelve declarando en configuración la lista de proxies confiables y descartando todo salto no confiable de la cadena. Sin esa lista, cualquiera puede escribir en su propia auditoría la IP que quiera, y el campo deja de ser evidencia.
+
+**La IP no se enmascara.** El enmascaramiento del Art. XV.5 aplica a cuerpos de petición y respuesta; en la auditoría la IP *es* el dato. Queda sujeta, eso sí, a la política de retención (§9).
+
+#### 6.6.2 `audit_change_log` — creación y edición
+
+| Columna | Tipo | Descripción |
+|---|---|---|
+| `module` | `varchar` | Código del módulo (`SP`, `USR`, …) |
+| `entity` | `varchar` | Nombre lógico de la entidad (`roles`, `users`) |
+| `entity_id` | `uuid` | Identificador del registro afectado |
+| `action` | `varchar` | `CREATE` o `UPDATE`, con `CHECK` sobre el dominio cerrado |
+| `changes` | `jsonb` | En `CREATE`, el estado inicial. En `UPDATE`, solo los campos modificados |
+
+En una edición, `changes` registra el antes y el después **únicamente de lo que cambió**:
+
+```json
+{
+  "name":   { "before": "Supervisor", "after": "Supervisor de zona" },
+  "status": { "before": "ACTIVO",     "after": "INACTIVO" }
+}
+```
+
+Guardar el registro completo en cada edición multiplica el volumen y obliga a diferenciar a mano para responder «qué se editó». El diff responde esa pregunta directamente, y el estado completo se reconstruye aplicando los eventos en orden.
+
+Tres reglas que evitan huecos y ruido:
+
+- **Una edición que no modifica ningún campo no emite evento.** Un `UPDATE` con `changes` vacío es una fila sin información que ensucia la línea de tiempo.
+- **Restaurar un registro eliminado lógicamente se audita aquí**, como `UPDATE` sobre `deleted_at`. La fila de `audit_deletion_log` **permanece**: la eliminación ocurrió, y borrarla sería reescribir la historia.
+- **Los campos enmascarados nunca entran en `changes`.** Que una contraseña cambió se registra; su valor no, ni antes ni después (Art. IV.8).
+
+#### 6.6.3 `audit_deletion_log` — eliminación
+
+| Columna | Tipo | Descripción |
+|---|---|---|
+| `module`, `entity`, `entity_id` | | Igual que en `audit_change_log` |
+| `deletion_type` | `varchar` | `LOGICAL` o `PHYSICAL` |
+| `reason` | `text` **NOT NULL** | Motivo declarado por el actor (Art. V.13) |
+| `snapshot` | `jsonb` **NOT NULL** | Estado completo del registro al momento de eliminarse |
+
+El motivo es obligatorio en el esquema, y el esquema exige además que diga algo:
+
+```sql
+CONSTRAINT ck_deletion_reason CHECK (char_length(btrim(reason)) >= 10)
+```
+
+**Consecuencia sobre la API, que debe asumirse de forma consciente:** si el motivo es obligatorio, hay que pedirlo. Todo `DELETE` recibe un cuerpo JSON con el motivo y responde `400` si falta o no alcanza el mínimo:
+
+```
+DELETE /api/v1/roles/{id}
+
+{ "reason": "Rol duplicado tras la fusión de las áreas de cobranza." }
+```
+
+El cuerpo en `DELETE` es admisible en OpenAPI 3.1 y Spring lo soporta sin artificios, pero RFC 9110 no le define semántica y un intermediario podría descartarlo. Si eso llegara a ocurrir en el despliegue real, la alternativa declarada es la cabecera `X-Deletion-Reason`. **No** se usa parámetro de consulta: el motivo terminaría en la URL, y con ella en las trazas de acceso del proxy y en `request_log`.
+
+El `snapshot` es lo que vuelve útil a este registro. Sin él, la fila dice que el rol `018f3a…` fue eliminado y ya nadie recuerda qué rol era. Pasa por el mismo enmascarador que el resto: el estado de un usuario eliminado se conserva sin su `password_hash`.
+
+#### 6.6.4 `audit_error_log` — fallos
+
+| Columna | Tipo | Descripción |
+|---|---|---|
+| `resource` | `varchar` | Recurso afectado: entidad o ruta del endpoint |
+| `entity_id` | `uuid` NULL | Registro concreto, cuando el error se refiere a uno |
+| `operation` | `varchar` | Caso de uso, o método y ruta HTTP |
+| `error_code` | `varchar` | Código del contrato de error (§7.3) o de la regla incumplida (`RN-SEG-003`) |
+| `error_type` | `varchar` | `BUSINESS_RULE`, `INTEGRATION` o `UNHANDLED` |
+| `http_status` | `smallint` | Código devuelto al cliente |
+| `severity` | `varchar` | `MEDIA` o `ALTA` |
+| `message` | `text` | Mensaje saneado: sin trazas, SQL, rutas ni versiones (Art. VI.5) |
+
+**Qué entra y qué no.** El `request_log` ya registra toda petición fallida (Art. XV.4); duplicarlo entero no aportaría información y sí volumen. Aquí entra solo lo accionable:
+
+| Caso | ¿Auditoría de error? | Por qué |
+|---|---|---|
+| Excepción no controlada (`5xx`) | **Sí** | Es el fallo que hay que investigar |
+| Violación de una regla `RN-…` | **Sí** | Explica por qué el negocio rechazó la operación |
+| Fallo de una integración externa | **Sí** | Evidencia frente a un tercero |
+| Validación de formato (`400`) | No | Ruido de formulario; `request_log` ya lo cubre |
+| `401` o `404` | No | `request_log` ya lo cubre |
+| Denegación de autorización (`403`) | No — va a `audit_security_log` | Es un evento de control de acceso, no un fallo del sistema |
+
+La última fila es la frontera que importa: una denegación no es un error del sistema, es el sistema funcionando. Registrarla como error contamina la búsqueda de fallos reales.
+
+**El detalle técnico completo no vive aquí.** La traza va al log de aplicación, alcanzable por `correlation_id`. Esta tabla responde «a quién le falló qué», no «en qué línea».
+
+#### 6.6.5 `audit_security_log` — control de acceso
+
+Su catálogo de eventos, severidades y columnas propias se define en `security.md` §8, que es donde corresponde.
+
+#### 6.6.6 Consulta transversal
+
+Las cuatro tablas están separadas **para escribir**. Para leer hay dos preguntas legítimas y frecuentes que las cruzan: «todo lo que le pasó a esta entidad» y «todo lo que hizo esta persona». Se resuelven con una vista de solo lectura sobre el núcleo común:
+
+```sql
+CREATE VIEW v_audit_timeline AS
+    SELECT 'CHANGE' AS audit_type, id, occurred_at, actor_id, correlation_id,
+           ip_address, entity, entity_id, action AS summary
+      FROM audit_change_log
+    UNION ALL
+    SELECT 'DELETION', id, occurred_at, actor_id, correlation_id,
+           ip_address, entity, entity_id, deletion_type
+      FROM audit_deletion_log
+    UNION ALL
+    SELECT 'ERROR', id, occurred_at, actor_id, correlation_id,
+           ip_address, resource, entity_id, error_code
+      FROM audit_error_log
+    UNION ALL
+    SELECT 'SECURITY', id, occurred_at, actor_id, correlation_id,
+           ip_address, 'security', target_user_id, event_type
+      FROM audit_security_log;
+```
+
+La vista es **solo de lectura**: nada se escribe a través de ella. Cada tabla se escribe por su propio camino, con sus propias obligaciones. Consultarla exige los cuatro permisos de lectura; con un subconjunto se consulta cada tabla por separado (`security.md` §4.4).
+
+**Índices mínimos** en cada tabla — una auditoría que no puede consultarse no cumple su función:
+
+| Índice | Responde |
+|---|---|
+| `(entity, entity_id, occurred_at DESC)` | La línea de tiempo de un registro |
+| `(actor_id, occurred_at DESC)` | Todo lo que hizo una persona |
+| `(correlation_id)` | El enlace con `request_log` |
+| `(ip_address)` | Investigación por origen |
 
 ---
 
@@ -261,32 +422,47 @@ sequenceDiagram
     A->>U: invoca caso de uso
     U->>D: aplica reglas de negocio (RN-…)
     U->>R: persiste
-    R->>P: INSERT/UPDATE + audit_log (misma transacción)
+    R->>P: INSERT/UPDATE + audit_change_log / audit_deletion_log (misma transacción)
     P-->>R: commit
     U-->>A: resultado
     A-->>C: respuesta + correlationId
     F->>P: escribe request_log (fuera de la transacción de negocio)
 ```
 
-Dos puntos determinantes de este flujo:
+Tres puntos determinantes de este flujo, todos sobre **dónde** se escribe cada registro (Art. V.14):
 
-1. **`audit_log` se escribe dentro de la misma transacción** que el cambio de negocio. Si la operación se revierte, la auditoría también. Nunca queda un evento auditado que no ocurrió, ni un cambio sin auditar.
+1. **La auditoría de cambios y la de eliminación se escriben dentro de la misma transacción** que el cambio de negocio. Si la operación se revierte, su evento también. Nunca queda un evento auditado que no ocurrió, ni un cambio sin auditar. Si el evento falla, la operación falla.
 
-2. **`request_log` se escribe fuera de la transacción de negocio**, una vez emitida la respuesta. Así se cumple el Art. XV.7: un fallo al registrar la petición no puede tumbar una operación de negocio válida. La contrapartida es que el registro de peticiones es *best effort* y su indisponibilidad debe monitorearse.
+2. **La auditoría de error y la de seguridad se escriben en una transacción independiente** (`REQUIRES_NEW`). Es obligatorio y no es un detalle de implementación: estos dos registros se emiten justo cuando la transacción de negocio está siendo revertida. Escritos dentro de ella, el `rollback` borraría el evento junto con el fallo — un intento de inicio de sesión fallido no dejaría rastro, que es exactamente lo contrario de lo que se busca.
+
+3. **`request_log` se escribe fuera de la transacción de negocio**, una vez emitida la respuesta. Así se cumple el Art. XV.7: un fallo al registrar la petición no puede tumbar una operación de negocio válida. La contrapartida es que el registro de peticiones es *best effort* y su indisponibilidad debe monitorearse.
+
+| Registro | Transacción | Si falla su escritura |
+|---|---|---|
+| `audit_change_log` | La del cambio | Falla la operación de negocio |
+| `audit_deletion_log` | La del cambio | Falla la operación de negocio |
+| `audit_error_log` | Propia, independiente | No se propaga; queda en el log de aplicación como `ERROR` |
+| `audit_security_log` | Propia, independiente | No se propaga, salvo eventos declarados como requisito legal (Art. XV.7) |
+| `request_log` | Ninguna, posterior a la respuesta | No se propaga; *best effort* |
 
 ---
 
 ## 9. Observabilidad
 
-Implementa el Art. XV. Tres registros con propósitos distintos:
+Implementa el Art. XV. Seis registros con propósitos distintos — los cuatro de auditoría (§6.6), el de peticiones y el de aplicación:
 
 | Registro | Responde | Dónde vive | Retención |
 |---|---|---|---|
-| `audit_log` | Qué cambió en el negocio y quién lo cambió | PostgreSQL | Larga; no se purga sin decisión documentada (XV.8) |
+| `audit_change_log` | Quién creó y quién editó qué | PostgreSQL | Larga; no se purga sin decisión documentada (XV.8) |
+| `audit_deletion_log` | Quién eliminó qué y por qué | PostgreSQL | Larga; no se purga sin decisión documentada (XV.8) |
+| `audit_security_log` | Qué ocurrió en el control de acceso | PostgreSQL | Larga; no se purga sin decisión documentada (XV.8) |
+| `audit_error_log` | A quién le falló qué y con qué error | PostgreSQL | Acotada, mayor que la de `request_log` (XV.8) |
 | `request_log` | Qué se le pidió al sistema y qué respondió | PostgreSQL | Acotada, purga automatizada (XV.8) |
 | Log de aplicación | Qué ocurrió técnicamente durante la ejecución | Salida estándar, formato estructurado | Según la plataforma de ejecución |
 
-Los tres comparten el **identificador de correlación**, lo que permite reconstruir una operación completa a partir de un solo valor.
+Los seis comparten el **identificador de correlación**, lo que permite reconstruir una operación completa a partir de un solo valor. Los cinco que viven en PostgreSQL comparten además la **IP de origen** cuando la operación llegó por HTTP (Art. V.15), de modo que la pregunta «desde dónde se hizo esto» se responde sin depender de que `request_log` siga existiendo — y `request_log` es justamente el de retención más corta.
+
+Que la retención sea distinta por registro es una consecuencia buscada de la separación del Art. V.8: la auditoría de error acumula volumen y envejece rápido; la de eliminación no envejece nunca.
 
 **Enmascaramiento (Art. XV.5):** antes de persistir cualquier cuerpo de petición o respuesta se aplica una lista de campos sensibles (contraseñas, tokens, cabeceras `Authorization`, datos personales). El enmascaramiento es por lista de inclusión de lo que sí puede registrarse, no por lista de exclusión: un campo nuevo no declarado se enmascara por defecto.
 
@@ -375,7 +551,7 @@ Las decisiones D-01 a D-07, cerradas el 19-08-2026, están registradas en `const
 | # | Decisión | Bloquea | Responsable |
 |---|---|---|---|
 | D-09 | Infraestructura de despliegue para `testing` y `production` | Pipeline de despliegue | Responsable del proyecto |
-| D-10 | Retención concreta de `request_log` y `audit_log` (en días) | Migración de observabilidad | Responsable técnico |
+| D-10 | Retención concreta, en días, de `request_log` y de cada registro de auditoría por separado | Migración de observabilidad | Responsable técnico |
 | D-11 | Política de idempotencia en operaciones de escritura expuestas a reintentos | Diseño de endpoints críticos | Responsable técnico |
 
 D-08 quedó cerrada en `security.md` §12, junto con las decisiones D-12 a D-15 del modelo de autorización. Las pendientes propias de seguridad (D-16 a D-19) se registran en ese mismo documento.
@@ -388,4 +564,5 @@ D-08 quedó cerrada en `security.md` §12, junto con las decisiones D-12 a D-15 
 |---|---|---|---|
 | 0.1.0 | 19-08-2026 | Creación inicial. Incorpora las decisiones D-01 a D-07. | Responsable técnico |
 | 0.2.0 | 19-08-2026 | Cierre de D-08 en `security.md`. Referencia cruzada al modelo de seguridad. | Responsable técnico |
-| 0.3.0 | 19-08-2026 | Se retiran `created_by` y `updated_by` de las columnas obligatorias: el actor reside solo en `audit_log`. | Responsable técnico |
+| 0.3.0 | 19-08-2026 | Se retiran `created_by` y `updated_by` de las columnas obligatorias: el actor reside solo en la auditoría. | Responsable técnico |
+| 0.4.0 | 20-08-2026 | Nueva §6.6: la auditoría se separa en cuatro registros (cambios, eliminación, error y seguridad), con núcleo común, IP de origen y vista de consulta transversal. §8 incorpora la transaccionalidad diferenciada; §9 pasa de tres a seis registros de observabilidad. Enmienda la constitución 0.4.0. | Responsable técnico |

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -118,7 +118,7 @@ Aplica a todo el código, la documentación, las pruebas, la configuración y lo
 - **IV.4** Toda entrada proveniente del exterior DEBE validarse y sanearse antes de utilizarse.
 - **IV.5** Las consultas a base de datos DEBEN usar sentencias parametrizadas. NO DEBE construirse SQL por concatenación de cadenas.
 - **IV.6** Las comunicaciones DEBEN cifrarse en tránsito en los entornos de *testing* y *production*.
-- **IV.7** Los eventos relevantes de seguridad (autenticación, autorización denegada, cambios de permisos, operaciones sobre datos sensibles) DEBEN registrarse en la auditoría.
+- **IV.7** Los eventos relevantes de seguridad (autenticación, autorización denegada, cambios de permisos, operaciones sobre datos sensibles) DEBEN registrarse en la **auditoría de seguridad** definida en V.8.
 - **IV.8** Los registros de log NO DEBEN contener contraseñas, tokens ni datos personales sensibles.
 - **IV.9** Toda decisión que relaje un control de seguridad DEBE documentarse en `docs/security/` con su justificación y responsable.
 
@@ -140,14 +140,24 @@ Aplica a todo el código, la documentación, las pruebas, la configuración y lo
 - **V.4** Todo cambio de esquema DEBE realizarse mediante una migración versionada, incremental y revisada en Pull Request. NO DEBE modificarse el esquema manualmente en ningún entorno.
 - **V.5** Una migración ya integrada en `main` NO DEBE editarse; las correcciones se hacen con una migración nueva.
 - **V.6** El esquema DEBE aplicar integridad referencial explícita (claves foráneas, restricciones de unicidad, `NOT NULL`) en lugar de delegar la integridad únicamente a la capa de aplicación.
-- **V.7** Toda tabla de negocio DEBE incluir marcas de tiempo de creación y de última modificación. El **actor** responsable de cada cambio NO DEBE duplicarse en la tabla: reside únicamente en el registro de auditoría (V.8), que es su única fuente de verdad.
-- **V.8** La auditoría de negocio DEBE resolverse mediante un registro unificado de eventos (entidad, identificador, acción, actor, marca de tiempo y cambio aplicado), NO mediante una tabla por tipo de operación. Este registro se complementa con el registro de peticiones definido en el Art. XV, del cual se mantiene separado y con el cual DEBE poder correlacionarse. Al ser la única fuente del actor (V.7), toda operación que cree, modifique o elimine información de negocio DEBE producir su evento de auditoría: sin él, la autoría del cambio es irrecuperable.
+- **V.7** Toda tabla de negocio DEBE incluir marcas de tiempo de creación y de última modificación. El **actor** responsable de cada cambio NO DEBE duplicarse en la tabla: reside únicamente en los registros de auditoría (V.8), única fuente de verdad sobre quién hizo qué.
+- **V.8** La auditoría DEBE resolverse mediante **registros especializados por naturaleza del evento**, NO mediante un registro único genérico ni mediante una tabla por entidad. Se definen cuatro, y solo cuatro:
+
+    1. Auditoría de **cambios** — quién creó qué, y quién editó qué.
+    2. Auditoría de **eliminación** — quién eliminó qué, y **por qué** lo eliminó.
+    3. Auditoría de **error** — quién sufrió el fallo, sobre qué recurso, y qué error fue.
+    4. Auditoría de **seguridad** — autenticación, autorización y cambios de privilegio (Art. IV.7).
+
+    La separación es **física**: cada registro es su propia tabla con sus propias columnas obligatorias. La razón es que cada uno responde una pregunta distinta y exige un dato que a los demás no aplica —el motivo de una eliminación, el código de un error, la severidad de un evento de seguridad—; un registro único obliga a dejar opcional en el esquema lo que en su propio contexto es obligatorio, y la obligatoriedad deja de poder verificarse. Estos registros se complementan con el registro de peticiones del Art. XV, del cual se mantienen separados y con el cual DEBEN poder correlacionarse. Al ser la única fuente del actor (V.7), toda operación que cree, modifique o elimine información de negocio DEBE producir su evento: sin él, la autoría del cambio es irrecuperable.
 - **V.9** Las convenciones de nombres del esquema DEBEN ser uniformes: `snake_case`, tablas en plural, claves foráneas como `<entidad_singular>_id`.
 - **V.10** El borrado de información de negocio DEBERÍA ser lógico y reversible; el borrado físico DEBE justificarse en la especificación.
 - **V.11** Toda clave primaria DEBE ser de tipo `uuid` nativo de PostgreSQL, generada como **UUID v7** (ordenado por tiempo) para preservar la localidad de los índices. NO DEBEN exponerse identificadores secuenciales en la API.
 - **V.12** Las migraciones DEBEN gestionarse con **Flyway**, escritas en SQL plano de PostgreSQL, versionadas de forma incremental y almacenadas en el repositorio del backend.
+- **V.13** Toda eliminación —lógica o física— DEBE registrar el **motivo** declarado por quien la ejecuta. El motivo es obligatorio en el esquema y en el contrato de la API: una eliminación sin motivo DEBE rechazarse antes de ejecutarse. NO DEBE suplirse con un valor automático, salvo en procesos internos sin actor humano, que DEBEN declararse en la especificación. La auditoría de eliminación DEBE además conservar el **estado del registro al momento de eliminarse**: saber que algo se borró no sirve si ya no puede saberse qué era.
+- **V.14** Los registros de auditoría de **cambios** y de **eliminación** DEBEN escribirse en la misma transacción que el cambio que documentan: si el cambio se revierte, su evento también. Los de **error** y **seguridad** DEBEN escribirse en una **transacción independiente**, porque el evento que registran coincide con la reversión de la transacción de negocio; escritos dentro de ella, el rollback borraría precisamente la constancia del fallo.
+- **V.15** Todo registro de auditoría DEBE incluir la **dirección IP de origen** y el identificador de correlación de la operación. Cuando la operación no proviene de una petición HTTP, ambos DEBEN quedar explícitamente ausentes; NO DEBEN sustituirse por un valor ficticio que los haga indistinguibles de un origen real. La IP DEBE obtenerse de la cadena de proxies declarada como confiable, nunca de una cabecera provista por el cliente sin validar: una IP falsificable no es evidencia.
 
-**Verificación:** una base de datos vacía puede reconstruirse íntegramente ejecutando las migraciones del repositorio, en orden y sin intervención manual.
+**Verificación:** una base de datos vacía puede reconstruirse íntegramente ejecutando las migraciones del repositorio, en orden y sin intervención manual; y dada una entidad y su identificador, puede responderse quién la creó, quién la editó, quién la eliminó, por qué, y desde qué dirección IP.
 
 ---
 
@@ -332,16 +342,16 @@ Aplica a todo el código, la documentación, las pruebas, la configuración y lo
 
 - **XV.1** Toda petición HTTP DEBE recibir un **identificador de correlación** único, generado por el sistema si el cliente no lo provee, propagado a todo log y evento derivado, y devuelto al cliente en la respuesta.
 - **XV.2** El sistema DEBE mantener un **registro de peticiones** (`request_log`) que contenga como mínimo: identificador de correlación, actor autenticado (o su condición de anónimo), método HTTP, ruta, parámetros, código de estado, duración en milisegundos, origen (IP y agente de usuario), marca de tiempo y resultado de la respuesta.
-- **XV.3** El `request_log` y el `audit_log` son registros distintos y DEBEN mantenerse separados: el primero responde **qué se le pidió al sistema y qué respondió**; el segundo, **qué cambió en el negocio y quién lo cambió**. Ambos DEBEN poder correlacionarse mediante el identificador de correlación.
-- **XV.4** Las peticiones fallidas (`4xx` y `5xx`) DEBEN registrarse con el detalle del error, incluyendo el motivo del rechazo cuando se trate de una denegación de autenticación o autorización.
+- **XV.3** El `request_log` y los registros de auditoría del Art. V.8 son registros distintos y DEBEN mantenerse separados: el primero responde **qué se le pidió al sistema y qué respondió**; los segundos, **qué cambió en el negocio, quién lo cambió y por qué**. Todos DEBEN poder correlacionarse mediante el identificador de correlación.
+- **XV.4** Las peticiones fallidas (`4xx` y `5xx`) DEBEN registrarse con el detalle del error, incluyendo el motivo del rechazo cuando se trate de una denegación de autenticación o autorización. Los fallos no controlados y las violaciones de regla de negocio DEBEN además emitir su evento en la **auditoría de error** (V.8), que a diferencia del `request_log` es de retención prolongada y no es *best effort*.
 - **XV.5** El contenido de peticiones y respuestas DEBE enmascararse antes de persistirse: contraseñas, tokens, cabeceras de autorización y datos personales sensibles NO DEBEN quedar almacenados en ningún registro (Art. IV.8). Los cuerpos que superen el tamaño máximo definido DEBEN truncarse de forma explícita.
 - **XV.6** Los logs de aplicación DEBEN emitirse en formato estructurado, con nivel explícito y el identificador de correlación incorporado.
 - **XV.7** El registro de peticiones NO DEBE alterar el resultado ni el contrato de la operación: un fallo al registrar NO DEBE provocar el fallo de la petición de negocio, salvo en operaciones donde la auditoría constituya un requisito legal declarado en la especificación.
-- **XV.8** `request_log` y `audit_log` DEBEN tener una política de retención definida y automatizada. El `audit_log` NO DEBE purgarse sin una decisión documentada en `docs/security/`.
+- **XV.8** El `request_log` y cada registro de auditoría DEBEN tener una política de retención definida y automatizada, **propia de cada uno**: poder retenerlos de forma distinta es una de las razones de la separación del Art. V.8. Los registros de auditoría de cambios, de eliminación y de seguridad NO DEBEN purgarse sin una decisión documentada en `docs/security/`.
 - **XV.9** Umbrales de rendimiento del sistema (RNF): operaciones de lectura **p95 < 500 ms**; operaciones de escritura **p95 < 1 s**. El límite de 5 s del Documento Marco se interpreta como **techo absoluto**, nunca como objetivo. Toda operación que no pueda cumplir estos umbrales DEBE justificarlo y declarar su propio umbral en la especificación correspondiente.
 - **XV.10** El sistema DEBE exponer un endpoint de estado de salud, sin información sensible y sin requerir autenticación de negocio.
 
-**Verificación:** dado un identificador de correlación es posible reconstruir la petición completa, quién la ejecutó, qué respondió el sistema y qué cambió en el negocio.
+**Verificación:** dado un identificador de correlación es posible reconstruir la petición completa, quién la ejecutó, desde qué dirección IP, qué respondió el sistema, qué cambió en el negocio y —si falló— qué error se produjo.
 
 ---
 
@@ -408,7 +418,8 @@ docs/
 | ------- | ---------- | ---------------------------------------------------- | ------------------- |
 | 0.1.0   | 19-08-2026 | Creación inicial. Derivada del Documento Marco v1.0. | Responsable técnico |
 | 0.2.0   | 19-08-2026 | Cierre de las decisiones D-01 a D-07. Nuevo Art. XV (observabilidad y registro de operación). Nuevas reglas V.11, V.12, VIII.7, X.5, XII.6 y 17.6. | Responsable técnico |
-| 0.3.0   | 19-08-2026 | El actor de cada cambio deja de replicarse en las tablas de negocio y pasa a residir solo en `audit_log` (V.7, V.8). | Responsable técnico |
+| 0.3.0   | 19-08-2026 | El actor de cada cambio deja de replicarse en las tablas de negocio y pasa a residir solo en la auditoría (V.7, V.8). | Responsable técnico |
+| 0.4.0   | 20-08-2026 | La auditoría se separa en cuatro registros especializados: cambios, eliminación, error y seguridad (V.8, enmienda que invierte el sentido de la regla anterior). Nuevas reglas V.13 (motivo de eliminación obligatorio), V.14 (transaccionalidad diferenciada) y V.15 (IP de origen y correlación). Ajustes en IV.7, V.7, XV.3, XV.4 y XV.8. | Responsable técnico |
 
 
 ---
@@ -425,7 +436,7 @@ Registro de las decisiones técnicas resueltas. Cada una está incorporada como 
 | D-02 | Herramienta de construcción | Maven | POM declarativo y de convención estricta: legible y auditable en revisión de PR. | X.5 |
 | D-03 | Migraciones | Flyway con SQL plano de PostgreSQL | Migraciones versionadas e inmutables, sin capa de abstracción sobre un motor único. | V.12 |
 | D-04 | Clave primaria | `uuid` nativo generado como UUID v7 | Identificadores opacos como exige la plantilla, pero ordenados por tiempo para no fragmentar los índices. | V.11 |
-| D-05 | Auditoría | `audit_log` de eventos de negocio más `request_log` de peticiones, correlacionados | Separa el cambio de negocio de la actividad sobre la API: permite responder quién pidió qué, qué respondió el sistema y qué cambió. | V.8, Art. XV |
+| D-05 | Auditoría | Cuatro registros especializados —cambios, eliminación, error y seguridad— más el `request_log` de peticiones; todos correlacionados y con IP de origen | Separa el cambio de negocio de la actividad sobre la API, y separa entre sí preguntas que exigen campos distintos: «quién editó» no necesita un motivo, «por qué se eliminó» sí; «qué falló» necesita un código de error que a un alta no aplica. Un registro único los mezcla y vuelve opcional lo que en cada caso es obligatorio. | V.8, V.13–V.15, Art. XV |
 | D-06 | Rendimiento | p95 < 500 ms en lectura y p95 < 1 s en escritura; 5 s como techo absoluto | Convierte el RNF en una métrica verificable (Art. II.3) sin contradecir el Documento Marco. | XV.9 |
 | D-07 | Repositorios | Separados, sincronizados por contrato OpenAPI | Conserva los repositorios existentes, con ciclos de vida, CI y permisos independientes. | VIII.7, XII.6 |
 

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -304,7 +304,7 @@ Toda validación produce un código `VAL-NNN` declarado en la especificación, q
 
 - **Nunca** registres contraseñas, tokens, cabeceras `Authorization` ni datos personales sensibles (Art. IV.8, `security.md` §7.3).
 - Logs estructurados, con el identificador de correlación incorporado (Art. XV.6). Llega solo por el contexto de logging; no lo pases a mano.
-- **No uses el log como auditoría.** La auditoría es `audit_log` y tiene garantías transaccionales; el log no.
+- **No uses el log como auditoría.** La auditoría son los cuatro registros de `architecture.md` §6.6 y tiene garantías transaccionales; el log no. Escribir «usuario X eliminó el rol Y» en el log no sustituye la fila de `audit_deletion_log`: el log se purga, no se consulta por entidad y no exige el motivo.
 - **No registres una excepción y además la relances.** Produce el mismo error duplicado en el log. Relanza, y que la maneje quien corresponda.
 - Nada de `System.out.println`.
 
@@ -314,7 +314,8 @@ Toda validación produce un código `VAL-NNN` declarado en la especificación, q
 
 - `@Transactional` vive en la capa **`application`**, sobre el caso de uso. No en controladores ni en repositorios.
 - Una operación de negocio es **una** transacción. Si necesitas dos, probablemente son dos casos de uso.
-- **El evento de `audit_log` se escribe dentro de la misma transacción** que el cambio (`architecture.md` §8). Es obligatorio: es la única fuente del actor del cambio (Art. V.7, V.8).
+- **El evento de `audit_change_log` o `audit_deletion_log` se escribe dentro de la misma transacción** que el cambio (`architecture.md` §8). Es obligatorio: son la única fuente del actor del cambio (Art. V.7, V.8).
+- **La auditoría de error y la de seguridad van en transacción propia** (`@Transactional(propagation = REQUIRES_NEW)`). No es una preferencia: se emiten mientras la transacción de negocio se revierte, y escritas dentro de ella el `rollback` se lleva el evento (Art. V.14). Si escribes un evento de error en la transacción que acaba de fallar, no queda constancia de nada.
 - El `request_log` se escribe fuera de la transacción de negocio; de eso se encarga la infraestructura y no es responsabilidad del caso de uso.
 - Las consultas usan `@Transactional(readOnly = true)`.
 - **Nunca** ejecutes llamadas a sistemas externos dentro de una transacción abierta.
@@ -414,7 +415,11 @@ Reglas:
 - [ ] `mvn verify` pasa en local.
 - [ ] Hay pruebas para cada criterio de aceptación del requerimiento.
 - [ ] Las reglas de negocio están en `domain`, no en el controlador.
-- [ ] Toda escritura emite su evento de `audit_log`.
+- [ ] Toda creación y edición emite su evento en `audit_change_log`, con el diff de lo que cambió.
+- [ ] Toda eliminación emite su evento en `audit_deletion_log`, con motivo y `snapshot`; el endpoint rechaza la eliminación sin motivo.
+- [ ] Los fallos no controlados y los rechazos por regla de negocio emiten su evento en `audit_error_log`, en transacción independiente.
+- [ ] Los eventos de seguridad que toque el cambio están en `audit_security_log` (`security.md` §8).
+- [ ] Ningún evento de auditoría quedó sin IP de origen habiendo llegado por HTTP (Art. V.15).
 - [ ] Los endpoints nuevos declaran su permiso; ninguno quedó sin declaración.
 - [ ] La API nueva está documentada en OpenAPI y coincide con el comportamiento real.
 - [ ] No hay secretos, credenciales ni datos reales en el cambio.
@@ -446,7 +451,12 @@ Aplica el Artículo XIII. En términos prácticos:
 | `catch (Exception e) { log.error(...) }` y continuar | Convierte un fallo en un dato corrupto silencioso | Relanzar o manejar de verdad |
 | Regla de negocio como `@NotNull` en el DTO | Queda fuera del dominio y sin prueba unitaria | Validar en `domain` |
 | Consultar por otro módulo su repositorio | Rompe el límite del módulo | Usar la interfaz publicada (`architecture.md` §5.3) |
-| Agregar `created_by` a una tabla "por comodidad" | Duplica el actor que ya vive en `audit_log` y se desincroniza | Proyección sobre `audit_log` (Art. V.7) |
+| Agregar `created_by` a una tabla "por comodidad" | Duplica el actor que ya vive en la auditoría y se desincroniza | Proyección sobre `audit_change_log` (Art. V.7) |
+| Auditar el error dentro de la transacción que falló | El `rollback` borra el evento: el fallo ocurre y no queda rastro | Transacción independiente (Art. V.14) |
+| Rellenar el motivo de eliminación desde el código | El campo cumple el `NOT NULL` y no informa nada; "eliminado por el sistema" no es un motivo | Pedirlo en el contrato y rechazar la eliminación sin él (Art. V.13) |
+| Auditar un `UPDATE` con el registro completo | Multiplica el volumen y no responde qué cambió | Guardar solo el diff (`architecture.md` §6.6.2) |
+| Tomar la IP de `X-Forwarded-For` sin validar | Es una cabecera del cliente: cualquiera escribe su propia coartada | Resolverla contra la lista de proxies confiables (Art. V.15) |
+| Un solo evento para un cambio de rol | El cambio de negocio y el evento de seguridad se consultan con permisos distintos | Emitir ambos (`security.md` §8.1) |
 | Migración editada tras integrarse | Los entornos ya aplicados quedan divergentes | Migración nueva (Art. V.5) |
 | Prueba que solo verifica el mock | Pasa siempre, no prueba nada | Probar comportamiento observable |
 | `TODO` sin issue asociado | Nadie lo va a atender | Crear el issue o resolverlo |
@@ -459,3 +469,4 @@ Aplica el Artículo XIII. En términos prácticos:
 |---|---|---|---|
 | 0.1.0 | 19-08-2026 | Creación inicial. | Responsable técnico |
 | 0.2.0 | 19-08-2026 | Nueva sección 2.5: publicación de la documentación como sitio con MkDocs. | Responsable técnico |
+| 0.3.0 | 20-08-2026 | Se ajustan §9.2, §10, §13 y §15 a la separación de la auditoría en cuatro registros: transaccionalidad diferenciada, motivo de eliminación obligatorio e IP de origen. | Responsable técnico |

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,19 +100,19 @@ Toda funcionalidad cuenta con una especificación aprobada antes de que se escri
 
 | Documento | Versión | Estado |
 |---|---|---|
-| [Constitución](constitution.md) | 0.3.0 | Borrador |
-| [Arquitectura](architecture.md) | 0.3.0 | Borrador |
-| [Seguridad](security.md) | 0.2.0 | Borrador |
-| [Guía de desarrollo](development-guide.md) | 0.2.0 | Borrador |
-| [Mapa modular](modules.md) | 0.1.0 | Borrador |
+| [Constitución](constitution.md) | 0.4.0 | Borrador |
+| [Arquitectura](architecture.md) | 0.4.0 | Borrador |
+| [Seguridad](security.md) | 0.3.0 | Borrador |
+| [Guía de desarrollo](development-guide.md) | 0.3.0 | Borrador |
+| [Mapa modular](modules.md) | 0.2.0 | Borrador |
 | [Requerimientos y trazabilidad](requirements.md) | 0.2.0 | Borrador |
 | Estrategia de pruebas | — | Pendiente |
 
 ### Decisiones
 
-**Cerradas:** PostgreSQL como único motor · claves `uuid` v7 · Java 21 LTS con Spring Boot 3 y Maven · migraciones Flyway · auditoría separada en `audit_log` y `request_log` · umbrales p95 de rendimiento · repositorios separados con contrato OpenAPI · autenticación JWT con refresh revocable · contención de privilegios entre roles · permisos `recurso:acción` · Argon2id.
+**Cerradas:** PostgreSQL como único motor · claves `uuid` v7 · Java 21 LTS con Spring Boot 3 y Maven · migraciones Flyway · auditoría separada en cuatro registros —cambios, eliminación, error y seguridad— más `request_log`, todos con IP de origen · motivo obligatorio en toda eliminación · umbrales p95 de rendimiento · repositorios separados con contrato OpenAPI · autenticación JWT con refresh revocable · contención de privilegios entre roles · permisos `recurso:acción` · Argon2id.
 
-**Pendientes:** infraestructura de despliegue · retención de registros · política de idempotencia · parámetros concretos de seguridad · catálogo inicial de permisos · restablecimiento de contraseña · identidad para procesos automáticos.
+**Pendientes:** infraestructura de despliegue · retención por registro · política de idempotencia · parámetros concretos de seguridad · catálogo inicial de permisos · restablecimiento de contraseña · identidad para procesos automáticos · tipificación del motivo de eliminación · lista de proxies confiables por entorno.
 
 ---
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -125,7 +125,7 @@ La tabla anterior registra provisionalmente la primera salida. **Requiere confir
 
 **Propósito.** Gobierna quién puede hacer qué en el sistema y deja constancia de lo que ocurre. Es el módulo del que dependen todos los demás.
 
-**Alcance.** Catálogo de permisos, definición de roles, contención de privilegios entre roles y registro de auditoría.
+**Alcance.** Catálogo de permisos, definición de roles, contención de privilegios entre roles y los cuatro registros de auditoría (`architecture.md` §6.6). La auditoría se **consulta** desde aquí; se **escribe** desde cada módulo, en la operación que la origina.
 
 **No incluye.** Los usuarios y sus credenciales (eso es `USR`), ni la asignación de roles a personas.
 
@@ -133,7 +133,7 @@ La tabla anterior registra provisionalmente la primera salida. **Requiere confir
 |---|---|---|
 | Permisos | Catálogo de permisos `recurso:acción`. Solo lectura por API; se pueblan por migración | `permissions` |
 | Roles | Alta, edición, estado y contención de privilegios entre roles | `roles`, `role_permissions` |
-| Auditoría | Consulta del registro de eventos de negocio | `audit_log` |
+| Auditoría | Consulta de los cuatro registros de auditoría, por separado o desde la vista transversal | `audit_change_log`, `audit_deletion_log`, `audit_error_log`, `audit_security_log` |
 | Parámetros | Configuración transversal del sistema | *(por definir)* |
 
 **Dependencias.** Ninguna. Es la raíz del grafo, y debe seguir siéndolo: si `SP` llegara a depender de otro módulo, aparecería un ciclo.
@@ -236,3 +236,4 @@ El orden importa: el módulo precede al requerimiento, el requerimiento precede 
 | Versión | Fecha | Cambio | Responsable |
 |---|---|---|---|
 | 0.1.0 | 20-08-2026 | Creación inicial. Criterios de modularización y fichas de `SP` y `USR`. | Responsable técnico |
+| 0.2.0 | 20-08-2026 | El submódulo de auditoría de `SP` pasa de un registro único a los cuatro registros del Art. V.8. | Responsable técnico |

--- a/docs/security.md
+++ b/docs/security.md
@@ -50,7 +50,7 @@ Un usuario es la representación de una persona que accede al sistema. Los proce
 | `BLOQUEADO` | Bloqueado por intentos fallidos | No, hasta que expire el bloqueo o un administrador lo libere |
 | `PENDIENTE` | Creado pero sin activar su credencial | No |
 
-Un usuario **NO DEBE** eliminarse físicamente: se desactiva (Art. V.10). Eliminar el registro rompería la trazabilidad de todo lo que esa persona hizo: `audit_log` referencia al actor por su identificador, y ese identificador debe seguir resolviendo a un usuario.
+Un usuario **NO DEBE** eliminarse físicamente: se desactiva (Art. V.10). Eliminar el registro rompería la trazabilidad de todo lo que esa persona hizo: los cuatro registros de auditoría referencian al actor por su identificador, y ese identificador debe seguir resolviendo a un usuario.
 
 ### 3.2 Credenciales
 
@@ -137,8 +137,20 @@ Un permiso se identifica con el formato `<recurso>:<acción>`, en minúsculas:
 ```
 roles:read      roles:create      roles:update      roles:delete
 users:read      users:create      users:update      users:delete
-audit:read
+
+audit:read-changes      audit:read-deletions
+audit:read-errors       audit:read-security
 ```
+
+**La auditoría se lee por tipo, no en bloque.** Los cuatro registros del Art. V.8 responden preguntas distintas y no tienen la misma sensibilidad: quién editó un rol es información de operación; quién intentó entrar y falló es información de seguridad. Un único `audit:read` obligaría a dar acceso a la segunda para conceder la primera. Con permisos separados, soporte técnico puede investigar errores sin ver la actividad de autenticación de nadie:
+
+| Perfil | Permisos de auditoría |
+|---|---|
+| Soporte técnico | `audit:read-errors` |
+| Auditor de negocio | `audit:read-changes`, `audit:read-deletions` |
+| Responsable de seguridad | Los cuatro |
+
+La vista transversal `v_audit_timeline` (`architecture.md` §6.6.6) exige los cuatro permisos: mezcla las cuatro fuentes y no puede concederse parcialmente.
 
 - El **recurso** corresponde a una entidad o agrupación funcional del módulo.
 - La **acción** es una de un conjunto cerrado: `read`, `create`, `update`, `delete`, más acciones específicas del dominio cuando la especificación lo justifique (por ejemplo `users:reset-password`).
@@ -270,23 +282,52 @@ Implementa el Art. XV.5. Antes de persistir cualquier contenido en `request_log`
 
 ## 8. Auditoría de seguridad
 
-Los siguientes eventos **DEBEN** registrarse en `audit_log` (Art. IV.7), además del `request_log` general:
+Es uno de los cuatro registros del Art. V.8, y el único que este documento define en detalle; los otros tres están en `architecture.md` §6.6. Responde **qué ocurrió en el control de acceso**: quién intentó entrar, a quién se le negó qué, y quién cambió los privilegios de quién.
 
-| Evento | Severidad |
-|---|---|
-| Inicio de sesión exitoso | Informativa |
-| Inicio de sesión fallido | Media |
-| Bloqueo de cuenta por intentos fallidos | Alta |
-| Reutilización de un refresh token revocado | **Alta** |
-| Cierre de sesión | Informativa |
-| Denegación de autorización (`403`) | Media |
-| Creación, modificación o eliminación de un rol | Alta |
-| Cambio de permisos de un rol | **Alta** |
-| Asignación o retiro de roles a un usuario | **Alta** |
-| Cambio de estado de un usuario | Alta |
-| Cambio o restablecimiento de contraseña | Alta |
+### 8.1 Eventos
 
-Los registros de auditoría **NO DEBEN** contener contraseñas ni tokens, ni siquiera en su forma hasheada (Art. IV.8). El `audit_log` no se purga sin decisión documentada (Art. XV.8).
+Los siguientes **DEBEN** registrarse en `audit_security_log` (Art. IV.7), además del `request_log` general:
+
+| Evento | Severidad | `outcome` |
+|---|---|---|
+| Inicio de sesión exitoso | Informativa | `SUCCESS` |
+| Inicio de sesión fallido | Media | `FAILURE` |
+| Bloqueo de cuenta por intentos fallidos | Alta | `FAILURE` |
+| Reutilización de un refresh token revocado | **Alta** | `FAILURE` |
+| Cierre de sesión | Informativa | `SUCCESS` |
+| Denegación de autorización (`403`) | Media | `FAILURE` |
+| Creación, modificación o eliminación de un rol | Alta | `SUCCESS` |
+| Cambio de permisos de un rol | **Alta** | `SUCCESS` |
+| Asignación o retiro de roles a un usuario | **Alta** | `SUCCESS` |
+| Cambio de estado de un usuario | Alta | `SUCCESS` |
+| Cambio o restablecimiento de contraseña | Alta | `SUCCESS` |
+
+La denegación de autorización se registra **aquí y no en `audit_error_log`**: un `403` no es un fallo del sistema, es el sistema funcionando. Tratarlo como error contamina la búsqueda de fallos reales (`architecture.md` §6.6.4).
+
+Los cambios de rol, de permisos y de estado producen **dos** eventos, no uno: el de cambio de negocio en `audit_change_log`, con el diff de lo que cambió, y el de seguridad aquí, con su severidad. No es duplicación: responden preguntas distintas y se consultan con permisos distintos.
+
+### 8.2 Columnas propias
+
+Sobre el núcleo común de `architecture.md` §6.6.1 —que ya aporta actor, correlación, **IP de origen** y agente de usuario—, este registro agrega:
+
+| Columna | Tipo | Descripción |
+|---|---|---|
+| `event_type` | `varchar` | Evento de §8.1, con `CHECK` sobre el catálogo cerrado |
+| `severity` | `varchar` | `INFORMATIVA`, `MEDIA` o `ALTA` |
+| `outcome` | `varchar` | `SUCCESS` o `FAILURE` |
+| `target_user_id` | `uuid` NULL | Usuario **objeto** del evento, distinto del actor |
+| `detail` | `jsonb` NULL | Contexto adicional, sujeto al enmascaramiento de §7.3 |
+
+`target_user_id` es la columna que distingue «quién lo hizo» de «a quién se lo hicieron». Sin ella, un bloqueo de cuenta o una asignación de rol no dice sobre quién recayó. En un inicio de sesión fallido, el actor es desconocido —todavía no hay identidad probada— y el usuario que se intentó usar va aquí.
+
+**La IP es especialmente relevante en este registro.** Un intento de fuerza bruta se reconoce por el origen, no por el nombre de usuario: quien lo ejecuta prueba muchos usuarios desde la misma IP, o el mismo usuario desde muchas. Ambas consultas dependen de que la IP esté en cada fila y sea confiable, de ahí la exigencia del Art. V.15 sobre la cadena de proxies.
+
+### 8.3 Garantías
+
+- **Transacción independiente** (Art. V.14). Un inicio de sesión fallido ocurre mientras la transacción se revierte; escrito dentro de ella, el `rollback` borraría exactamente el evento que hay que conservar.
+- **Sin secretos.** Estos registros **NO DEBEN** contener contraseñas ni tokens, ni siquiera hasheados (Art. IV.8). Un evento de reutilización de refresh token identifica el token por su registro, nunca por su valor.
+- **Sin purga silenciosa.** `audit_security_log` no se purga sin decisión documentada en `docs/security/` (Art. XV.8).
+- **Lectura restringida.** Requiere `audit:read-security` (§4.4), que se concede aparte de los demás permisos de auditoría.
 
 ---
 
@@ -302,8 +343,11 @@ Estructura lógica. Las columnas exactas se fijan en la migración Flyway corres
 | `role_permissions` | Permisos declarados por rol | `role_id`, `permission_id` |
 | `user_roles` | Roles asignados a usuarios | `user_id`, `role_id`, `created_at` |
 | `refresh_tokens` | Sesiones revocables | `user_id`, `token_hash`, `expires_at`, `revoked_at`, `replaced_by_id`, `ip`, `user_agent` |
+| `audit_security_log` | Eventos de control de acceso (§8) | `event_type`, `severity`, `outcome`, `target_user_id`, `detail`, más el núcleo común (`actor_id`, `correlation_id`, `ip_address`, `user_agent`) |
 
-Todas siguen las convenciones de `architecture.md` §6: clave primaria `uuid` v7, marcas de tiempo de creación y modificación, y restricciones declaradas en el esquema. Ninguna almacena el actor del cambio: quién asignó un rol o quién modificó un permiso se responde desde `audit_log` (Art. V.7). Por eso los eventos de §8 no son opcionales — son la única fuente de esa información.
+Todas siguen las convenciones de `architecture.md` §6: clave primaria `uuid` v7, marcas de tiempo de creación y modificación, y restricciones declaradas en el esquema. Ninguna almacena el actor del cambio: quién asignó un rol o quién modificó un permiso se responde desde `audit_change_log`, y quién eliminó un rol y por qué, desde `audit_deletion_log` (Art. V.7). Por eso los eventos de §8 no son opcionales — junto con esos dos registros son la única fuente de esa información.
+
+`audit_security_log` es la excepción a la regla anterior: no es una tabla de negocio sino un registro de eventos, por lo que no lleva `updated_at` ni borrado lógico. **Es de solo inserción**: no se actualiza ni se elimina fila alguna, y ese comportamiento debe estar restringido a nivel de privilegios de base de datos, no solo por convención en el código. Un registro de seguridad que la aplicación puede reescribir no prueba nada.
 
 **Restricciones que deben existir en la base de datos, no solo en Java** (Art. V.6):
 
@@ -331,6 +375,9 @@ Todas siguen las convenciones de `architecture.md` §6: clave primaria `uuid` v7
 | Enumeración de usuarios | Respuestas y tiempos indistinguibles |
 | Inyección SQL | Consultas parametrizadas (Art. IV.5) |
 | Fuga de datos por registros | Enmascaramiento por lista de inclusión (§7.3) |
+| IP falsificada en la auditoría | La IP se resuelve contra la lista de proxies confiables, nunca desde una cabecera del cliente (Art. V.15) |
+| Eliminación sin rastro de qué se eliminó | `snapshot` obligatorio en `audit_deletion_log` (Art. V.13) |
+| Reescritura de la evidencia de seguridad | `audit_security_log` es de solo inserción, restringido por privilegios de base de datos (§9) |
 | Secreto filtrado en el repositorio | Prohibición absoluta y política de rotación (§7.1) |
 | Endpoint publicado por olvido | Denegar por defecto; lista explícita de endpoints públicos (§6) |
 
@@ -345,7 +392,8 @@ Todas siguen las convenciones de `architecture.md` §6: clave primaria `uuid` v7
 | **RNF-SEG-003** | Ningún secreto está presente en el repositorio. | Verificación automatizada en CI |
 | **RNF-SEG-004** | Las contraseñas se almacenan con Argon2id. | Revisión de código e inspección de esquema |
 | **RNF-SEG-005** | Ningún registro contiene contraseñas, tokens ni cabeceras de autorización. | Prueba sobre el enmascarador |
-| **RNF-SEG-006** | Los eventos de seguridad de §8 quedan registrados en `audit_log`. | Pruebas de integración por evento |
+| **RNF-SEG-006** | Los eventos de seguridad de §8 quedan registrados en `audit_security_log`, con su IP de origen y en transacción independiente. | Pruebas de integración por evento, incluyendo una que verifica que el evento persiste tras el `rollback` de la operación fallida |
+| **RNF-SEG-007** | Toda eliminación registra un motivo; la API rechaza la eliminación sin él. | Prueba de contrato por cada endpoint `DELETE` |
 
 RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrados y verifica que cada uno declara su exigencia de permiso. Es la única forma de garantizar que un endpoint nuevo no quede expuesto por descuido.
 
@@ -371,6 +419,8 @@ RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrado
 | D-17 | Catálogo inicial completo de permisos y roles de sistema | Primera migración de seguridad |
 | D-18 | Política de restablecimiento de contraseña (canal, vigencia del enlace) | Módulo de usuarios |
 | D-19 | Identidad para procesos automáticos e integraciones | Cuando exista la primera integración |
+| D-20 | Si el motivo de eliminación debe tipificarse (catálogo de códigos) además del texto libre del actor | Especificación de los endpoints `DELETE` de cada módulo |
+| D-21 | Lista de proxies confiables por entorno, de la que depende la validez de la IP registrada (Art. V.15) | Despliegue en `testing` y `production` |
 
 ---
 
@@ -379,4 +429,5 @@ RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrado
 | Versión | Fecha | Cambio | Responsable |
 |---|---|---|---|
 | 0.1.0 | 19-08-2026 | Creación inicial. Cierra D-08 y define el modelo de contención de privilegios. | Responsable técnico |
-| 0.2.0 | 19-08-2026 | `user_roles` deja de registrar `assigned_by`: el actor de la asignación reside en `audit_log`. | Responsable técnico |
+| 0.2.0 | 19-08-2026 | `user_roles` deja de registrar `assigned_by`: el actor de la asignación reside en la auditoría. | Responsable técnico |
+| 0.3.0 | 20-08-2026 | §8 pasa a definir `audit_security_log` como uno de los cuatro registros del Art. V.8: columnas propias, `target_user_id`, IP de origen y transacción independiente. §4.4 sustituye `audit:read` por cuatro permisos de lectura por tipo. Nuevo RNF-SEG-007 y pendientes D-20 y D-21. | Responsable técnico |


### PR DESCRIPTION
Enmienda de diseno del responsable tecnico. La auditoria pasa de un registro unico generico a cuatro tablas, una por naturaleza del evento: cambios, eliminacion, error y seguridad.

El motivo es que cada una responde una pregunta distinta y exige un dato que a las demas no aplica: "quien edito" no necesita un motivo, "por que se elimino" si; "que fallo" necesita un codigo de error y una severidad. Con un registro unico habria que dejar opcional en el esquema lo que en su propio contexto es obligatorio, y la obligatoriedad deja de poder verificarse. Con la separacion, cada tabla declara NOT NULL lo que realmente lo es.

constitution.md v0.4.0

- V.8 reescrita. Invierte el sentido de la regla anterior, que exigia registro unificado. Por 17.4 esto seria MAJOR; por 17.6, en estado Borrador se acumula como MINOR.
- V.13 nueva: toda eliminacion registra el motivo declarado por el actor, con el motivo obligatorio en el esquema y en el contrato de la API, y conserva el estado del registro al momento de eliminarse. Saber que algo se borro no sirve si ya no puede saberse que era.
- V.14 nueva: transaccionalidad diferenciada. Cambios y eliminacion se escriben en la transaccion del cambio que documentan; error y seguridad, en transaccion independiente, porque el evento que registran coincide con la reversion de la transaccion de negocio y el rollback borraria precisamente la constancia del fallo.
- V.15 nueva: todo evento lleva IP de origen y correlacion, resueltas contra la cadena de proxies declarada como confiable. Una IP tomada de X-Forwarded-For sin validar no es evidencia.

architecture.md v0.4.0

- Seccion 6.6 con las cuatro tablas, su nucleo comun de seis columnas y las columnas propias de cada una.
- La IP usa el tipo nativo inet y no se enmascara: en auditoria la IP es el dato, no un contenido de la peticion.
- Restriccion ck_audit_origen: correlacion e IP son nulas a la vez o presentes a la vez, de modo que una fila sin IP significa inequivocamente que no vino de la red, nunca que se olvido registrarla.
- Criterio explicito de que entra en audit_error_log. La denegacion de autorizacion no entra: es el sistema funcionando, no un fallo, y va a audit_security_log. Registrarla como error contaminaria la busqueda de fallos reales.
- Consecuencia sobre la API: si el motivo es obligatorio hay que pedirlo, de modo que DELETE lleva cuerpo JSON con el motivo.

security.md v0.3.0

- Seccion 8 con el catalogo cerrado de eventos, su severidad y su outcome.
- Los permisos de lectura de auditoria se segregan por tipo de registro (audit:read-errors, audit:read-changes, audit:read-deletions), porque los cuatro registros no tienen la misma sensibilidad y no deben leerse en bloque.

development-guide.md v0.3.0

- Reglas de transaccionalidad por tipo de evento, con REQUIRES_NEW para error y seguridad.
- Checklist previo al Pull Request ampliado con los cuatro registros.
- Seis antipatrones nuevos, entre ellos auditar el error dentro de la transaccion que fallo, rellenar el motivo de eliminacion desde el codigo y tomar la IP de X-Forwarded-For sin validar.

modules.md v0.2.0: el submodulo de auditoria de SP pasa a los cuatro registros.

Quedan abiertas dos decisiones nuevas: D-20, si el motivo de eliminacion debe tipificarse con un catalogo de codigos ademas del texto libre, y D-21, la lista de proxies confiables por entorno, de la que depende la validez de la IP registrada.

Verificado: mkdocs build --strict construye sin advertencias y no queda ninguna referencia al registro unico anterior en la documentacion.