### PR TITLE
Feature/base documental y modulo sp

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,33 +1,49 @@
 name: Documentación
 
 # Construye el sitio de documentación con MkDocs y lo publica en GitHub Pages.
-# En Pull Request solo construye: sirve de verificación de que la documentación
-# sigue siendo válida (enlaces, navegación, sintaxis) antes de integrar.
+#
+# En Pull Request solo construye: verifica que la documentación sigue siendo
+# válida —enlaces, navegación, sintaxis— antes de integrar.
+# En develop construye y publica.
+#
+# Se publica desde develop y no desde main porque la documentación técnica vale
+# por estar al día: con el flujo feature -> develop -> main, main puede llevar
+# semanas de retraso. Es además la rama a la que apunta `edit_uri` en
+# mkdocs.yml. Para publicar desde main, cambiar las tres referencias a develop:
+# el filtro `branches` y los dos `if` de rama.
 
 on:
   push:
-    branches: [main]
+    branches: [develop]
     paths:
       - "docs/**"
+      # Los archivos .pages controlan la navegación del sitio y empiezan por
+      # punto: los patrones glob no los alcanzan, hay que nombrarlos aparte.
+      - "docs/.pages"
+      - "docs/**/.pages"
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "docs/**"
+      - "docs/.pages"
+      - "docs/**/.pages"
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 
+# Permiso mínimo por defecto. Los permisos de publicación se conceden
+# únicamente al job que despliega (Art. IV.2, principio de mínimo privilegio).
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
+# Una ejecución por rama. Los despliegues no se cancelan entre sí para no
+# dejar el sitio a medio publicar; las construcciones de Pull Request sí.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   construir:
@@ -53,16 +69,19 @@ jobs:
         run: mkdocs build --strict
 
       - name: Publicar el artefacto
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/develop'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   desplegar:
     name: Desplegar en GitHub Pages
-    if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/develop'
     needs: construir
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.despliegue.outputs.page_url }}

--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,14 @@
+# Orden y títulos de la navegación. Gestionado por mkdocs-awesome-pages-plugin.
+# Las carpetas de especificaciones se incorporan solas: no hay que tocar
+# mkdocs.yml al crear una tripleta nueva.
+# "..." recoge cualquier documento no listado, para que nada quede invisible.
+nav:
+  - Inicio: index.md
+  - Constitución: constitution.md
+  - Arquitectura: architecture.md
+  - Seguridad: security.md
+  - Mapa modular: modules.md
+  - Requerimientos y trazabilidad: requirements.md
+  - Guía de desarrollo: development-guide.md
+  - specs
+  - ...

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,13 +5,13 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `architecture.md` |
-| Versión | 0.3.0 |
+| Versión | 0.4.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
 | Última actualización | 19-08-2026 |
-| Documento superior | `constitution.md` v0.3.0 |
-| Documento relacionado | `security.md` v0.2.0 |
+| Documento superior | `constitution.md` v0.5.0 |
+| Documento relacionado | `security.md` v0.3.0 |
 
 ---
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `architecture.md` |
-| Versión | 0.4.0 |
+| Versión | 0.5.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
@@ -254,14 +254,17 @@ Tres reglas que evitan huecos y ruido:
 | Columna | Tipo | Descripción |
 |---|---|---|
 | `module`, `entity`, `entity_id` | | Igual que en `audit_change_log` |
-| `deletion_type` | `varchar` | `LOGICAL` o `PHYSICAL` |
-| `reason` | `text` **NOT NULL** | Motivo declarado por el actor (Art. V.13) |
+| `deletion_type` | `varchar` | `LOGICAL`, `PHYSICAL` o `ASSOCIATION` |
+| `reason` | `text` | Motivo declarado por el actor. Obligatorio salvo en `ASSOCIATION` (Art. V.13) |
 | `snapshot` | `jsonb` **NOT NULL** | Estado completo del registro al momento de eliminarse |
 
-El motivo es obligatorio en el esquema, y el esquema exige además que diga algo:
+El motivo es obligatorio en el esquema para las entidades de negocio, y el esquema exige además que diga algo:
 
 ```sql
-CONSTRAINT ck_deletion_reason CHECK (char_length(btrim(reason)) >= 10)
+CONSTRAINT ck_deletion_reason CHECK (
+    deletion_type = 'ASSOCIATION'
+ OR char_length(btrim(reason)) >= 10
+)
 ```
 
 **Consecuencia sobre la API, que debe asumirse de forma consciente:** si el motivo es obligatorio, hay que pedirlo. Todo `DELETE` recibe un cuerpo JSON con el motivo y responde `400` si falta o no alcanza el mínimo:
@@ -566,3 +569,4 @@ D-08 quedó cerrada en `security.md` §12, junto con las decisiones D-12 a D-15 
 | 0.2.0 | 19-08-2026 | Cierre de D-08 en `security.md`. Referencia cruzada al modelo de seguridad. | Responsable técnico |
 | 0.3.0 | 19-08-2026 | Se retiran `created_by` y `updated_by` de las columnas obligatorias: el actor reside solo en la auditoría. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | Nueva §6.6: la auditoría se separa en cuatro registros (cambios, eliminación, error y seguridad), con núcleo común, IP de origen y vista de consulta transversal. §8 incorpora la transaccionalidad diferenciada; §9 pasa de tres a seis registros de observabilidad. Enmienda la constitución 0.4.0. | Responsable técnico |
+| 0.5.0 | 20-08-2026 | `audit_deletion_log` admite `deletion_type = ASSOCIATION`, donde el motivo no es exigible (Art. V.13 enmendado). | Responsable técnico |

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -6,7 +6,7 @@
 | Proyecto             | NEXUS — Renovación de plataforma                                                           |
 | Empresa              | FACTECH GROUP SAS                                                                          |
 | Documento            | `constitution.md`                                                                          |
-| Versión              | 0.6.0                                                                                      |
+| Versión              | 0.7.0                                                                                      |
 | Estado               | Borrador                                                                                   |
 | Responsable técnico  | Bonilla Diaz William Steven                                                                |
 | Fecha de creación    | 19-08-2026                                                                                 |
@@ -164,7 +164,7 @@ Aplica a todo el código, la documentación, las pruebas, la configuración y lo
 - **V.10** El borrado de información de negocio DEBERÍA ser lógico y reversible; el borrado físico DEBE justificarse en la especificación.
 - **V.11** Toda clave primaria DEBE ser de tipo `uuid` nativo de PostgreSQL, generada como **UUID v7** (ordenado por tiempo) para preservar la localidad de los índices. NO DEBEN exponerse identificadores secuenciales en la API.
 - **V.12** Las migraciones DEBEN gestionarse con **Flyway**, escritas en SQL plano de PostgreSQL, versionadas de forma incremental y almacenadas en el repositorio del backend.
-- **V.13** Toda eliminación —lógica o física— DEBE registrar el **motivo** declarado por quien la ejecuta. El motivo es obligatorio en el esquema y en el contrato de la API: una eliminación sin motivo DEBE rechazarse antes de ejecutarse. NO DEBE suplirse con un valor automático, salvo en procesos internos sin actor humano, que DEBEN declararse en la especificación. La auditoría de eliminación DEBE además conservar el **estado del registro al momento de eliminarse**: saber que algo se borró no sirve si ya no puede saberse qué era.
+- **V.13** Toda eliminación —lógica o física— DEBE registrar el **motivo** declarado por quien la ejecuta. El motivo es obligatorio en el esquema y en el contrato de la API: una eliminación sin motivo DEBE rechazarse antes de ejecutarse. NO DEBE suplirse con un valor automático, salvo en dos casos, que DEBEN declararse en la especificación: los procesos internos sin actor humano, y la eliminación de **asociaciones** —filas de relación cuyo significado se agota en el par que vinculan, como un permiso asignado a un rol—. En una asociación el «por qué» ya está contenido en el propio evento (qué se desvinculó, de qué, quién y cuándo), y exigir un texto libre solo produciría ruido. La excepción NO alcanza a las entidades de negocio. La auditoría de eliminación DEBE además conservar el **estado del registro al momento de eliminarse**: saber que algo se borró no sirve si ya no puede saberse qué era.
 - **V.14** Los registros de auditoría de **cambios** y de **eliminación** DEBEN escribirse en la misma transacción que el cambio que documentan: si el cambio se revierte, su evento también. Los de **error** y **seguridad** DEBEN escribirse en una **transacción independiente**, porque el evento que registran coincide con la reversión de la transacción de negocio; escritos dentro de ella, el rollback borraría precisamente la constancia del fallo.
 - **V.15** Todo registro de auditoría DEBE incluir la **dirección IP de origen** y el identificador de correlación de la operación. Cuando la operación no proviene de una petición HTTP, ambos DEBEN quedar explícitamente ausentes; NO DEBEN sustituirse por un valor ficticio que los haga indistinguibles de un origen real. La IP DEBE obtenerse de la cadena de proxies declarada como confiable, nunca de una cabecera provista por el cliente sin validar: una IP falsificable no es evidencia.
 
@@ -433,6 +433,7 @@ docs/
 | 0.4.0   | 20-08-2026 | La auditoría se separa en cuatro registros especializados: cambios, eliminación, error y seguridad (V.8, enmienda que invierte el sentido de la regla anterior). Nuevas reglas V.13 (motivo de eliminación obligatorio), V.14 (transaccionalidad diferenciada) y V.15 (IP de origen y correlación). Ajustes en IV.7, V.7, XV.3, XV.4 y XV.8. | Responsable técnico |
 | 0.5.0   | 20-08-2026 | El Artículo I adopta la tripleta `spec` / `plan` / `tasks` con compuertas sucesivas de aprobación (I.1 a I.8). Se declara la divergencia con la §22 del Documento Marco. | Responsable técnico |
 | 0.6.0   | 20-08-2026 | I.3 incorpora precondiciones y postcondiciones al contenido mínimo de `spec.md`: la plantilla de requerimientos las exigía y la tripleta no las recogía. | Responsable técnico |
+| 0.7.0   | 20-08-2026 | V.13 admite eliminar asociaciones sin motivo declarado. La excepción queda acotada a las filas de relación y no alcanza a las entidades de negocio. | Responsable técnico |
 
 
 ---

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -6,7 +6,7 @@
 | Proyecto             | NEXUS — Renovación de plataforma                                                           |
 | Empresa              | FACTECH GROUP SAS                                                                          |
 | Documento            | `constitution.md`                                                                          |
-| Versión              | 0.5.0                                                                                      |
+| Versión              | 0.6.0                                                                                      |
 | Estado               | Borrador                                                                                   |
 | Responsable técnico  | Bonilla Diaz William Steven                                                                |
 | Fecha de creación    | 19-08-2026                                                                                 |
@@ -60,7 +60,7 @@ Aplica a todo el código, la documentación, las pruebas, la configuración y lo
 
 - **I.1** Toda funcionalidad DEBE contar con una **tripleta** aprobada en `docs/specs/` antes de iniciar su implementación: `spec.md`, `plan.md` y `tasks.md`. Los tres son obligatorios; ninguno sustituye a otro.
 - **I.2** Cada tripleta corresponde a **exactamente un** requerimiento funcional identificado como `RF-[MÓDULO]-NNN`, y vive en `docs/specs/<módulo>/<NNN>-<nombre>/`. Si un requerimiento resulta demasiado grande para una tripleta, se divide el **requerimiento**, no la tripleta.
-- **I.3** `spec.md` responde **qué debe pasar y por qué**. DEBE contener, como mínimo: objetivo, contexto, actores, alcance y no alcance, reglas de negocio aplicables, datos de entrada y salida en lenguaje de negocio, flujo principal, flujos alternativos, excepciones, validaciones, criterios de aceptación y casos límite. **NO DEBE** contener decisiones técnicas: si un cambio de tecnología la invalidaría, ese contenido pertenece a `plan.md`. Una `spec.md` con preguntas abiertas NO DEBE aprobarse.
+- **I.3** `spec.md` responde **qué debe pasar y por qué**. DEBE contener, como mínimo: objetivo, contexto, actores, alcance y no alcance, reglas de negocio aplicables, datos de entrada y salida en lenguaje de negocio, precondiciones y postcondiciones, flujo principal, flujos alternativos, excepciones, validaciones, criterios de aceptación y casos límite. **NO DEBE** contener decisiones técnicas: si un cambio de tecnología la invalidaría, ese contenido pertenece a `plan.md`. Una `spec.md` con preguntas abiertas NO DEBE aprobarse.
 - **I.4** `plan.md` responde **cómo se construye**. DEBE contener, como mínimo: enfoque, cambios de esquema, componentes afectados por capa, contrato de API, permisos requeridos, eventos de auditoría a emitir, transaccionalidad, impacto sobre otros módulos, alternativas consideradas y estrategia de prueba.
 - **I.5** `tasks.md` responde **en qué pasos**. DEBE descomponer el plan en tareas ordenadas, con dependencias explícitas, cada una verificable de forma objetiva y del tamaño de un commit. Es la **fuente de verdad** de las tareas: los Issues del repositorio la referencian y NO DEBEN duplicarla. Toda tarea DEBE poder rastrearse a un criterio de aceptación de `spec.md`.
 - **I.6** Los tres documentos se aprueban en **compuertas sucesivas**: `plan.md` NO DEBE escribirse hasta que `spec.md` esté aprobada, y `tasks.md` NO DEBE escribirse hasta que `plan.md` lo esté. Ninguna línea de código se escribe antes de que `tasks.md` esté aprobado. Cada compuerta se tramita en su propio Pull Request.
@@ -432,6 +432,7 @@ docs/
 | 0.3.0   | 19-08-2026 | El actor de cada cambio deja de replicarse en las tablas de negocio y pasa a residir solo en la auditoría (V.7, V.8). | Responsable técnico |
 | 0.4.0   | 20-08-2026 | La auditoría se separa en cuatro registros especializados: cambios, eliminación, error y seguridad (V.8, enmienda que invierte el sentido de la regla anterior). Nuevas reglas V.13 (motivo de eliminación obligatorio), V.14 (transaccionalidad diferenciada) y V.15 (IP de origen y correlación). Ajustes en IV.7, V.7, XV.3, XV.4 y XV.8. | Responsable técnico |
 | 0.5.0   | 20-08-2026 | El Artículo I adopta la tripleta `spec` / `plan` / `tasks` con compuertas sucesivas de aprobación (I.1 a I.8). Se declara la divergencia con la §22 del Documento Marco. | Responsable técnico |
+| 0.6.0   | 20-08-2026 | I.3 incorpora precondiciones y postcondiciones al contenido mínimo de `spec.md`: la plantilla de requerimientos las exigía y la tripleta no las recogía. | Responsable técnico |
 
 
 ---

--- a/docs/constitution.md
+++ b/docs/constitution.md
@@ -6,7 +6,7 @@
 | Proyecto             | NEXUS — Renovación de plataforma                                                           |
 | Empresa              | FACTECH GROUP SAS                                                                          |
 | Documento            | `constitution.md`                                                                          |
-| Versión              | 0.3.0                                                                                      |
+| Versión              | 0.5.0                                                                                      |
 | Estado               | Borrador                                                                                   |
 | Responsable técnico  | Bonilla Diaz William Steven                                                                |
 | Fecha de creación    | 19-08-2026                                                                                 |
@@ -26,7 +26,7 @@ En caso de conflicto, prevalece el documento de mayor jerarquía:
 
 1. **Constitución** (este documento) — principios no negociables.
 2. **Documento Marco** — estándares y metodología.
-3. **Especificación del módulo** (`docs/specs/`) — comportamiento esperado de cada funcionalidad.
+3. **Tripleta de la funcionalidad** (`docs/specs/`) — `spec.md` (qué y por qué), `plan.md` (cómo) y `tasks.md` (en qué pasos).
 4. **Decisiones de arquitectura** (`docs/architecture/`) — decisiones técnicas registradas.
 5. **Implementación** — el código.
 
@@ -58,13 +58,24 @@ Aplica a todo el código, la documentación, las pruebas, la configuración y lo
 
 **Reglas**
 
-- **I.1** Toda funcionalidad DEBE contar con una especificación aprobada en `docs/specs/` antes de iniciar su implementación.
-- **I.2** Toda especificación DEBE originarse en un requerimiento identificado bajo la nomenclatura `RF-[MÓDULO]-NNN`, `RNF-[CATEGORÍA]-NNN` o `RN-[MÓDULO]-NNN`.
-- **I.3** La especificación DEBE contener, como mínimo: objetivo, contexto, requerimiento asociado, reglas de negocio, datos, flujo, validaciones, criterios de aceptación, casos límite, consideraciones técnicas y pruebas.
-- **I.4** Si durante la implementación se descubre que la especificación es incompleta o incorrecta, se DEBE detener el desarrollo, corregir la especificación y luego continuar. NO DEBE resolverse la ambigüedad únicamente en el código.
-- **I.5** Las correcciones triviales sin impacto funcional (formato, typos, comentarios) PUEDEN realizarse sin especificación previa.
+- **I.1** Toda funcionalidad DEBE contar con una **tripleta** aprobada en `docs/specs/` antes de iniciar su implementación: `spec.md`, `plan.md` y `tasks.md`. Los tres son obligatorios; ninguno sustituye a otro.
+- **I.2** Cada tripleta corresponde a **exactamente un** requerimiento funcional identificado como `RF-[MÓDULO]-NNN`, y vive en `docs/specs/<módulo>/<NNN>-<nombre>/`. Si un requerimiento resulta demasiado grande para una tripleta, se divide el **requerimiento**, no la tripleta.
+- **I.3** `spec.md` responde **qué debe pasar y por qué**. DEBE contener, como mínimo: objetivo, contexto, actores, alcance y no alcance, reglas de negocio aplicables, datos de entrada y salida en lenguaje de negocio, flujo principal, flujos alternativos, excepciones, validaciones, criterios de aceptación y casos límite. **NO DEBE** contener decisiones técnicas: si un cambio de tecnología la invalidaría, ese contenido pertenece a `plan.md`. Una `spec.md` con preguntas abiertas NO DEBE aprobarse.
+- **I.4** `plan.md` responde **cómo se construye**. DEBE contener, como mínimo: enfoque, cambios de esquema, componentes afectados por capa, contrato de API, permisos requeridos, eventos de auditoría a emitir, transaccionalidad, impacto sobre otros módulos, alternativas consideradas y estrategia de prueba.
+- **I.5** `tasks.md` responde **en qué pasos**. DEBE descomponer el plan en tareas ordenadas, con dependencias explícitas, cada una verificable de forma objetiva y del tamaño de un commit. Es la **fuente de verdad** de las tareas: los Issues del repositorio la referencian y NO DEBEN duplicarla. Toda tarea DEBE poder rastrearse a un criterio de aceptación de `spec.md`.
+- **I.6** Los tres documentos se aprueban en **compuertas sucesivas**: `plan.md` NO DEBE escribirse hasta que `spec.md` esté aprobada, y `tasks.md` NO DEBE escribirse hasta que `plan.md` lo esté. Ninguna línea de código se escribe antes de que `tasks.md` esté aprobado. Cada compuerta se tramita en su propio Pull Request.
+- **I.7** Si durante la implementación se descubre que la tripleta es incompleta o incorrecta, se DEBE detener el desarrollo, corregir el documento que corresponda **volviendo a su compuerta** y continuar. NO DEBE resolverse la ambigüedad únicamente en el código.
+- **I.8** Las correcciones triviales sin impacto funcional (formato, typos, comentarios) PUEDEN realizarse sin tripleta previa.
 
-**Verificación:** el Pull Request referencia el identificador del requerimiento y la ruta de su especificación.
+**Verificación:** el Pull Request referencia el identificador del requerimiento y la ruta de su tripleta.
+
+!!! note "Divergencia declarada con el Documento Marco"
+
+    La §22 del Documento Marco describe **una sola** especificación por funcionalidad. Este artículo la sustituye por la tripleta `spec` / `plan` / `tasks`.
+
+    El motivo es que la lista de contenidos que el Documento Marco exige mezcla tres cosas de naturaleza distinta —comportamiento, decisiones técnicas y descomposición del trabajo—, con audiencias y momentos de aprobación distintos. Separarlas permite que el negocio apruebe el qué sin discutir el cómo, y evita planear sobre una especificación que todavía va a cambiar.
+
+    La constitución prevalece sobre el Documento Marco (§0.1). La divergencia se declara aquí para que no quede tácita.
 
 ---
 
@@ -420,6 +431,7 @@ docs/
 | 0.2.0   | 19-08-2026 | Cierre de las decisiones D-01 a D-07. Nuevo Art. XV (observabilidad y registro de operación). Nuevas reglas V.11, V.12, VIII.7, X.5, XII.6 y 17.6. | Responsable técnico |
 | 0.3.0   | 19-08-2026 | El actor de cada cambio deja de replicarse en las tablas de negocio y pasa a residir solo en la auditoría (V.7, V.8). | Responsable técnico |
 | 0.4.0   | 20-08-2026 | La auditoría se separa en cuatro registros especializados: cambios, eliminación, error y seguridad (V.8, enmienda que invierte el sentido de la regla anterior). Nuevas reglas V.13 (motivo de eliminación obligatorio), V.14 (transaccionalidad diferenciada) y V.15 (IP de origen y correlación). Ajustes en IV.7, V.7, XV.3, XV.4 y XV.8. | Responsable técnico |
+| 0.5.0   | 20-08-2026 | El Artículo I adopta la tripleta `spec` / `plan` / `tasks` con compuertas sucesivas de aprobación (I.1 a I.8). Se declara la divergencia con la §22 del Documento Marco. | Responsable técnico |
 
 
 ---

--- a/docs/development-guide.md
+++ b/docs/development-guide.md
@@ -5,13 +5,13 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `development-guide.md` |
-| Versión | 0.2.0 |
+| Versión | 0.4.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
 | Última actualización | 19-08-2026 |
-| Documento superior | `constitution.md` v0.3.0 |
-| Documentos relacionados | `architecture.md` v0.3.0, `security.md` v0.2.0 |
+| Documento superior | `constitution.md` v0.5.0 |
+| Documentos relacionados | `architecture.md` v0.4.0, `security.md` v0.3.0 |
 
 ---
 
@@ -90,7 +90,9 @@ mkdocs build --strict   # construye en site/ y falla ante cualquier advertencia
 
 Reglas al tocar la documentación:
 
-- Todo documento nuevo **DEBE** agregarse a `nav` en `mkdocs.yml`. Con `--strict`, un documento fuera de la navegación o un enlace roto **detiene el pipeline**.
+- La navegación **no** se declara en `mkdocs.yml`: la genera `mkdocs-awesome-pages-plugin` a partir de los archivos `.pages` de cada carpeta. Una tripleta nueva aparece sola en el sitio, sin tocar configuración ni provocar conflictos de merge.
+- Para fijar el orden o el título de una sección, se edita el `.pages` de esa carpeta. Lo que no se lista queda recogido por `...` al final, de modo que ningún documento se vuelve invisible por olvido.
+- Con `--strict`, un enlace roto **detiene el pipeline**.
 - Los enlaces entre documentos se escriben como rutas relativas al archivo `.md` (`[Seguridad](security.md)`), no como URLs del sitio publicado. Así funcionan igual en GitHub, en el editor y en el sitio.
 - Los diagramas se escriben en bloques ` ```mermaid `, que se renderizan tanto en GitHub como en el sitio.
 - El directorio `site/` es un artefacto de construcción y no se versiona (Art. XI.5).
@@ -104,19 +106,26 @@ El sitio se publica automáticamente en GitHub Pages al integrar en `main`. En P
 El ciclo completo, en el orden en que ocurre (Art. I, III):
 
 ```
-1. Requerimiento aprobado          docs/requirements/<modulo>.md   → RF-XXX-NNN
-2. Especificación escrita          docs/specs/<modulo>/<caso>.md
-3. Issue creado en GitHub          referencia el RF
-4. Rama de trabajo                 feature/<descripcion-corta>
-5. Implementación + pruebas        en el mismo commit o commits contiguos
-6. mvn verify en verde             local, antes de publicar
-7. Pull Request                    con la plantilla de §12.3
-8. Revisión y aprobación           al menos una persona distinta del autor
-9. Integración                     a develop
-10. Trazabilidad actualizada       matriz en docs/requirements.md
+ 1. Requerimiento aprobado      docs/requirements/<modulo>.md
+ 2. spec.md escrita             docs/specs/<modulo>/<NNN>-<nombre>/spec.md
+ 3. COMPUERTA 1                 spec aprobada — Pull Request propio
+ 4. plan.md escrito             .../plan.md
+ 5. COMPUERTA 2                 plan aprobado — Pull Request propio
+ 6. tasks.md escrito            .../tasks.md
+ 7. COMPUERTA 3                 tasks aprobadas — Pull Request propio
+ 8. Issue creado en GitHub      referencia el RF y enlaza a tasks.md
+ 9. Rama de trabajo             feature/<descripcion-corta>
+10. Implementación + pruebas    en el orden que fija tasks.md
+11. mvn verify en verde         local, antes de publicar
+12. Pull Request                con la plantilla de §12.3
+13. Revisión y aprobación       al menos una persona distinta del autor
+14. Integración                 a develop
+15. Trazabilidad actualizada    matriz en docs/requirements.md
 ```
 
-**No empieces por el paso 5.** Si no existe la especificación, escríbela o pídela; implementar sin ella produce código que nadie puede validar (Art. I.1).
+**No empieces por el paso 10.** Las tres compuertas del Art. I.6 existen para que el negocio apruebe el *qué* sin discutir el *cómo*, y para no planear sobre una especificación que todavía va a cambiar. Son tres Pull Requests pequeños y rápidos de revisar, no tres semanas de espera.
+
+**Los cambios de la tripleta que se descubran implementando** vuelven a su compuerta (Art. I.7): no se resuelven en el código ni se anotan «para después».
 
 ---
 
@@ -180,7 +189,10 @@ El número es estrictamente creciente y **nunca** se reutiliza. Si dos ramas tom
 Archivos que se tocan al implementar `RF-SP-001 — Registrar rol`. Sirve como plantilla mental de lo que un Pull Request debe contener:
 
 ```
-docs/specs/security/create-role.md              Especificación (existe antes del código)
+docs/specs/sp/001-registrar-rol/                Tripleta (aprobada antes del código)
+  spec.md                                       Qué debe pasar y por qué
+  plan.md                                       Cómo se construye
+  tasks.md                                      En qué pasos
 
 src/main/resources/db/migration/
   V2__create_roles.sql                          Esquema
@@ -381,7 +393,7 @@ Contenido obligatorio (Art. III.4):
 ```markdown
 ## Requerimiento
 RF-SP-001 — Registrar rol
-Especificación: docs/specs/security/create-role.md
+Tripleta: docs/specs/sp/001-registrar-rol/
 Issue: #25
 
 ## Descripción del cambio
@@ -470,3 +482,4 @@ Aplica el Artículo XIII. En términos prácticos:
 | 0.1.0 | 19-08-2026 | Creación inicial. | Responsable técnico |
 | 0.2.0 | 19-08-2026 | Nueva sección 2.5: publicación de la documentación como sitio con MkDocs. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | Se ajustan §9.2, §10, §13 y §15 a la separación de la auditoría en cuatro registros: transaccionalidad diferenciada, motivo de eliminación obligatorio e IP de origen. | Responsable técnico |
+| 0.4.0 | 20-08-2026 | Se adopta la tripleta `spec` / `plan` / `tasks`: §3 incorpora las tres compuertas y §5 y §12.3 apuntan a la carpeta de la tripleta. §2.5 pasa a navegación por `.pages`. | Responsable técnico |

--- a/docs/index.md
+++ b/docs/index.md
@@ -102,12 +102,13 @@ Ninguna línea de código se escribe antes de que la tripleta esté aprobada (Ar
 
 | Documento | Versión | Estado |
 |---|---|---|
-| [Constitución](constitution.md) | 0.5.0 | Borrador |
-| [Arquitectura](architecture.md) | 0.4.0 | Borrador |
-| [Seguridad](security.md) | 0.3.0 | Borrador |
+| [Constitución](constitution.md) | 0.7.0 | Borrador |
+| [Arquitectura](architecture.md) | 0.5.0 | Borrador |
+| [Seguridad](security.md) | 0.7.0 | Borrador |
+| [Mapa modular](modules.md) | 0.7.0 | Borrador |
+| [Requerimientos y trazabilidad](requirements.md) | 0.5.0 | Borrador |
 | [Guía de desarrollo](development-guide.md) | 0.4.0 | Borrador |
-| [Mapa modular](modules.md) | 0.3.0 | Borrador |
-| [Requerimientos y trazabilidad](requirements.md) | 0.3.0 | Borrador |
+| [Requerimientos de `SP`](requirements/sp.md) | 1.0.0 | **Aprobado** |
 | Estrategia de pruebas | — | Pendiente |
 
 ### Decisiones

--- a/docs/index.md
+++ b/docs/index.md
@@ -85,10 +85,12 @@ Si la implementación necesita contradecir una regla constitucional, **primero s
 El proyecto sigue **Spec-Driven Development**: la especificación es la fuente de verdad y precede a la implementación.
 
 ```
-Requerimiento → Especificación → Issue → Pull Request → Código → Prueba → Resultado
+Requerimiento → spec.md → plan.md → tasks.md → Issue → Pull Request → Código → Prueba
 ```
 
-Toda funcionalidad cuenta con una especificación aprobada antes de que se escriba su primera línea de código (Art. I.1), y todo cambio es reconstruible hasta el requerimiento que lo originó (Art. III.1).
+Cada funcionalidad se documenta en una **tripleta**: `spec.md` responde *qué debe pasar y por qué*, `plan.md` responde *cómo se construye* y `tasks.md` responde *en qué pasos*. Los tres se aprueban en compuertas sucesivas (Art. I.6).
+
+Ninguna línea de código se escribe antes de que la tripleta esté aprobada (Art. I.1), y todo cambio es reconstruible hasta el requerimiento que lo originó (Art. III.1).
 
 ---
 
@@ -100,12 +102,12 @@ Toda funcionalidad cuenta con una especificación aprobada antes de que se escri
 
 | Documento | Versión | Estado |
 |---|---|---|
-| [Constitución](constitution.md) | 0.4.0 | Borrador |
+| [Constitución](constitution.md) | 0.5.0 | Borrador |
 | [Arquitectura](architecture.md) | 0.4.0 | Borrador |
 | [Seguridad](security.md) | 0.3.0 | Borrador |
-| [Guía de desarrollo](development-guide.md) | 0.3.0 | Borrador |
-| [Mapa modular](modules.md) | 0.2.0 | Borrador |
-| [Requerimientos y trazabilidad](requirements.md) | 0.2.0 | Borrador |
+| [Guía de desarrollo](development-guide.md) | 0.4.0 | Borrador |
+| [Mapa modular](modules.md) | 0.3.0 | Borrador |
+| [Requerimientos y trazabilidad](requirements.md) | 0.3.0 | Borrador |
 | Estrategia de pruebas | — | Pendiente |
 
 ### Decisiones

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `modules.md` |
-| Versión | 0.3.0 |
+| Versión | 0.4.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -104,18 +104,18 @@ Las dependencias apuntan **del consumidor al proveedor** y deben ser acíclicas 
 
 Un módulo `Obsoleto` conserva su fila y su código: sus requerimientos siguen referenciados en la historia del proyecto.
 
-### 4.1 Punto abierto: código de módulo frente a nombre de paquete
+### 4.1 Código de módulo y nombre de paquete
 
 Los ejemplos de `architecture.md` y `security.md` usan el paquete `modules/security` para el trabajo de roles y permisos, mientras que el Documento Marco asigna ese alcance al módulo `SP` (Sistema Principal), cuyo paquete natural es `modules/system`.
 
-Hay que resolverlo **antes de escribir la primera clase**: el nombre queda fijado en cientos de archivos y en la ruta de cada especificación.
+Se resolvió el 20-08-2026, antes de redactar el primer requerimiento: el código queda inmutable en cuanto se use en un identificador (§2.1), de modo que no podía postergarse.
 
 | Salida | A favor | En contra |
 |---|---|---|
 | `SP` → `modules/system` | Conserva la nomenclatura del Documento Marco, ya aprobado | `system` describe peor el contenido real del módulo |
 | Renombrar el módulo a `SEG` → `modules/security` | El nombre dice lo que el módulo hace | `SEG` ya se usa como categoría de RNF y como prefijo de las reglas `RN-SEG-…`, lo que genera ambigüedad |
 
-La tabla anterior registra provisionalmente la primera salida. **Requiere confirmación.**
+**Decisión: `SP` → `modules/system`.** Conserva la nomenclatura del Documento Marco, que ya está aprobado y usa `RF-SP-001` como ejemplo. Los ejemplos de `architecture.md` y `security.md` que mencionan `modules/security` deben leerse como `modules/system`.
 
 ---
 
@@ -240,3 +240,4 @@ El orden importa: el módulo precede al requerimiento, el requerimiento precede 
 | 0.1.0 | 20-08-2026 | Creación inicial. Criterios de modularización y fichas de `SP` y `USR`. | Responsable técnico |
 | 0.2.0 | 20-08-2026 | El submódulo de auditoría de `SP` pasa de un registro único a los cuatro registros del Art. V.8. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | §8 se ajusta a la tripleta `spec` / `plan` / `tasks` y a la navegación automática del sitio. | Responsable técnico |
+| 0.4.0 | 20-08-2026 | Se cierra el punto abierto §4.1: el módulo `SP` usa el paquete `modules/system`. | Responsable técnico |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `modules.md` |
-| Versión | 0.5.0 |
+| Versión | 0.6.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -125,16 +125,20 @@ Se resolvió el 20-08-2026, antes de redactar el primer requerimiento: el códig
 
 **Propósito.** Gobierna quién puede hacer qué en el sistema y deja constancia de lo que ocurre. Es el módulo del que dependen todos los demás.
 
-**Alcance.** Catálogo de permisos, definición de roles, contención de privilegios entre roles y los cuatro registros de auditoría (`architecture.md` §6.6). La auditoría se **consulta** desde aquí; se **escribe** desde cada módulo, en la operación que la origina.
+**Alcance.** Catálogo de permisos, definición de roles, contención de privilegios entre roles, catálogos transversales (membresías, monedas y países) y los cuatro registros de auditoría (`architecture.md` §6.6). La auditoría se **consulta** desde aquí; se **escribe** desde cada módulo, en la operación que la origina.
 
 **No incluye.** Los usuarios y sus credenciales (eso es `USR`), ni la asignación de roles a personas.
 
 | Submódulo | Responsabilidad | Entidades principales |
 |---|---|---|
+| Roles | Alta, consulta, edición, estado, jerarquía y eliminación lógica | `roles` |
 | Permisos | Catálogo de permisos `recurso:acción`. Solo lectura por API; se pueblan por migración | `permissions` |
-| Roles | Alta, edición, estado y contención de privilegios entre roles | `roles`, `role_permissions` |
+| Roles y permisos | Asociación y revocación de permisos sobre un rol | `role_permissions` |
+| Membresías | Nivel de acceso del consumidor a servicios y contenidos | `memberships` |
+| Monedas | Catálogo de monedas | `currencies` |
+| Países | Catálogo de países | `countries` |
 | Auditoría | Consulta de los cuatro registros de auditoría, por separado o desde la vista transversal | `audit_change_log`, `audit_deletion_log`, `audit_error_log`, `audit_security_log` |
-| Parámetros | Configuración transversal del sistema | *(por definir)* |
+
 
 **Dependencias.** Ninguna. Es la raíz del grafo, y debe seguir siéndolo: si `SP` llegara a depender de otro módulo, aparecería un ciclo.
 
@@ -258,3 +262,4 @@ El orden importa: el módulo precede al requerimiento, el requerimiento precede 
 | 0.3.0 | 20-08-2026 | §8 se ajusta a la tripleta `spec` / `plan` / `tasks` y a la navegación automática del sitio. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | Se cierra el punto abierto §4.1: el módulo `SP` usa el paquete `modules/system`. | Responsable técnico |
 | 0.5.0 | 20-08-2026 | §6 registra las siete áreas candidatas deducidas de la Épica 2 (HU08–HU14) y el conflicto de nomenclatura entre historias de usuario y requerimientos. | Responsable técnico |
+| 0.6.0 | 20-08-2026 | Los submódulos de `SP` se ajustan a la guía `guides/001-sp.md`: se separan roles y permisos, y se incorporan membresías, monedas y países. Se retira «Parámetros», cubierto por los catálogos. | Responsable técnico |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `modules.md` |
-| Versión | 0.6.0 |
+| Versión | 0.7.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -207,15 +207,17 @@ La Épica 2 del documento de historias de usuario (HU08–HU14) define siete rol
 | Señales | HU14 | Publicación y consumo de señales |
 | Métricas | HU08 | Indicadores y reportes de la plataforma |
 
-!!! danger "Candidatos, no decisiones"
+!!! warning "Candidatos, no decisiones"
 
-    Son áreas **deducidas de los roles**, no un inventario aprobado. El documento de historias de usuario se está entregando por partes: hasta tener las demás épicas, ni los límites ni los códigos de estos módulos pueden fijarse.
+    Son áreas **deducidas de los roles**, no un inventario aprobado. El documento de origen se está entregando por partes: hasta disponer del alcance completo, ni los límites ni los códigos de estos módulos pueden fijarse.
 
-    Los ejemplos del Documento Marco apuntaban a *gestión de activos e inventario* (*"nombre del activo"*, `feature/registrar-activo`). No aparecen en esta épica: hay que confirmar si siguen vigentes o eran material de plantilla.
+    Los ejemplos del Documento Marco apuntaban a *gestión de activos e inventario* (*"nombre del activo"*, `feature/registrar-activo`). No aparecen en el alcance conocido hasta ahora: queda por confirmar si siguen vigentes o eran material de plantilla.
 
-!!! warning "Nomenclatura por resolver"
+!!! note "Las historias de usuario son documento de origen"
 
-    El documento de origen usa épicas e historias `HU08`; el proyecto usa `RF-[MÓDULO]-NNN`. Una historia de usuario **no** equivale a un requerimiento funcional: *«quiero ver mi estructura comercial»* son varios `RF`. Hay que decidir si las historias se convierten en requerimientos, o si conviven ambas nomenclaturas con trazabilidad entre ellas.
+    El documento de historias usa épicas e identificadores `HU`; el proyecto usa `RF-[MÓDULO]-NNN`. Una historia **no** equivale a un requerimiento funcional: *«quiero ver mi estructura comercial»* son varios `RF`.
+
+    Las historias sirven para **levantar** requerimientos, pero quedan **fuera de la cadena de trazabilidad**, que es `RF` → tripleta → Pull Request → código → prueba (Art. III.1). Las referencias `HU` que aparecen en esta sección son procedencia del candidato, no trazabilidad.
 
 Para cada área de negocio que se incorpore hay que responder:
 
@@ -263,3 +265,4 @@ El orden importa: el módulo precede al requerimiento, el requerimiento precede 
 | 0.4.0 | 20-08-2026 | Se cierra el punto abierto §4.1: el módulo `SP` usa el paquete `modules/system`. | Responsable técnico |
 | 0.5.0 | 20-08-2026 | §6 registra las siete áreas candidatas deducidas de la Épica 2 (HU08–HU14) y el conflicto de nomenclatura entre historias de usuario y requerimientos. | Responsable técnico |
 | 0.6.0 | 20-08-2026 | Los submódulos de `SP` se ajustan a la guía `guides/001-sp.md`: se separan roles y permisos, y se incorporan membresías, monedas y países. Se retira «Parámetros», cubierto por los catálogos. | Responsable técnico |
+| 0.7.0 | 20-08-2026 | Se resuelve la relación entre historias de usuario y requerimientos: las historias son documento de origen y quedan fuera de la trazabilidad. | Responsable técnico |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `modules.md` |
-| Versión | 0.4.0 |
+| Versión | 0.5.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -191,11 +191,27 @@ Se resolvió el 20-08-2026, antes de redactar el primer requerimiento: el códig
 
 Esta sección es el trabajo pendiente para cerrar el diseño modular.
 
-El Documento Marco no enumera los módulos del producto, pero sus ejemplos apuntan a un dominio de **gestión de activos e inventario**: la plantilla de requerimientos usa como campos de muestra *"nombre del activo"* y *"código interno"*, y los ejemplos de ramas incluyen `feature/registrar-activo` y `fix/error-inventario`.
+La Épica 2 del documento de historias de usuario (HU08–HU14) define siete roles, y de sus alcances se deducen las áreas de negocio del producto:
 
-!!! danger "Estos módulos no están decididos"
+| Candidato | Deducido de | Alcance aparente |
+|---|---|---|
+| Red comercial | HU10, HU11, HU12 | Estructura manager → director → agente y su relación entre personas |
+| Comisiones | HU08, HU10, HU12 | FTDs, cálculo y liquidación de comisiones |
+| Finanzas | HU09 | Retiros, pagos, balances y egresos |
+| Productos y servicios | HU08, HU13 | Catálogo, compras |
+| Academia | HU08, HU13, HU14 | Cursos y sesiones en vivo |
+| Señales | HU14 | Publicación y consumo de señales |
+| Métricas | HU08 | Indicadores y reportes de la plataforma |
 
-    Lo anterior son **indicios**, no decisiones. Se registran aquí para no perderlos, y deben confirmarse, descartarse o completarse con el alcance real del producto antes de avanzar.
+!!! danger "Candidatos, no decisiones"
+
+    Son áreas **deducidas de los roles**, no un inventario aprobado. El documento de historias de usuario se está entregando por partes: hasta tener las demás épicas, ni los límites ni los códigos de estos módulos pueden fijarse.
+
+    Los ejemplos del Documento Marco apuntaban a *gestión de activos e inventario* (*"nombre del activo"*, `feature/registrar-activo`). No aparecen en esta épica: hay que confirmar si siguen vigentes o eran material de plantilla.
+
+!!! warning "Nomenclatura por resolver"
+
+    El documento de origen usa épicas e historias `HU08`; el proyecto usa `RF-[MÓDULO]-NNN`. Una historia de usuario **no** equivale a un requerimiento funcional: *«quiero ver mi estructura comercial»* son varios `RF`. Hay que decidir si las historias se convierten en requerimientos, o si conviven ambas nomenclaturas con trazabilidad entre ellas.
 
 Para cada área de negocio que se incorpore hay que responder:
 
@@ -241,3 +257,4 @@ El orden importa: el módulo precede al requerimiento, el requerimiento precede 
 | 0.2.0 | 20-08-2026 | El submódulo de auditoría de `SP` pasa de un registro único a los cuatro registros del Art. V.8. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | §8 se ajusta a la tripleta `spec` / `plan` / `tasks` y a la navegación automática del sitio. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | Se cierra el punto abierto §4.1: el módulo `SP` usa el paquete `modules/system`. | Responsable técnico |
+| 0.5.0 | 20-08-2026 | §6 registra las siete áreas candidatas deducidas de la Épica 2 (HU08–HU14) y el conflicto de nomenclatura entre historias de usuario y requerimientos. | Responsable técnico |

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -5,13 +5,13 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `modules.md` |
-| Versión | 0.1.0 |
+| Versión | 0.3.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
 | Última actualización | 20-08-2026 |
-| Documento superior | `constitution.md` v0.3.0 |
-| Documentos relacionados | `architecture.md` v0.3.0, `requirements.md` v0.2.0 |
+| Documento superior | `constitution.md` v0.5.0 |
+| Documentos relacionados | `architecture.md` v0.4.0, `requirements.md` v0.3.0 |
 
 ---
 
@@ -224,10 +224,12 @@ Las preguntas 2 y 4 son las que determinan si es realmente un módulo (§2.1).
 2. Registrar la fila en el inventario de §4.
 3. Escribir su ficha en §5, a partir de la plantilla de §5.3.
 4. Crear `docs/requirements/<código en minúscula>.md` con la plantilla de requerimientos por módulo.
-5. Agregarlo a `nav` en `mkdocs.yml`, o la construcción del sitio falla (`development-guide.md` §2.5).
-6. Registrar sus requerimientos en la matriz de `requirements.md`.
+5. Registrar sus requerimientos en la matriz de `requirements.md`.
+6. Crear la carpeta `docs/specs/<código en minúscula>/`, donde vivirá la tripleta de cada requerimiento.
 
-El orden importa: el módulo precede al requerimiento, el requerimiento precede a la especificación y la especificación precede al código (Art. I.1).
+El sitio incorpora el módulo por sí solo: la navegación se genera desde los archivos `.pages` y no requiere tocar `mkdocs.yml`.
+
+El orden importa: el módulo precede al requerimiento, el requerimiento precede a la tripleta, y la tripleta —aprobada en sus tres compuertas— precede al código (Art. I.1, I.6).
 
 ---
 
@@ -237,3 +239,4 @@ El orden importa: el módulo precede al requerimiento, el requerimiento precede 
 |---|---|---|---|
 | 0.1.0 | 20-08-2026 | Creación inicial. Criterios de modularización y fichas de `SP` y `USR`. | Responsable técnico |
 | 0.2.0 | 20-08-2026 | El submódulo de auditoría de `SP` pasa de un registro único a los cuatro registros del Art. V.8. | Responsable técnico |
+| 0.3.0 | 20-08-2026 | §8 se ajusta a la tripleta `spec` / `plan` / `tasks` y a la navegación automática del sitio. | Responsable técnico |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `requirements.md` |
-| Versión | 0.3.0 |
+| Versión | 0.4.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -54,6 +54,8 @@ Reglas:
 - La numeración es correlativa **dentro de cada módulo** y **nunca se reutiliza**, ni siquiera si el requerimiento se descarta. Un identificador retirado se marca como `Descartado` en la matriz y su número queda consumido.
 - Los submódulos **no** intervienen en el identificador ([`modules.md` §2.2](modules.md#22-por-que-los-submodulos-no-llevan-codigo-propio)): mover una funcionalidad entre submódulos no debe cambiar su identificador.
 - El código de módulo, una vez usado en un identificador, **no se cambia jamás**.
+- **Las reglas de negocio admiten dos espacios.** `RN-[MÓDULO]-NNN` para las reglas propias de un módulo, y `RN-SEG-NNN` para las **reglas transversales de seguridad**, que gobiernan la autorización en todo el sistema y alcanzan a varios módulos a la vez. `SEG` es aquí un espacio de reglas transversales, no un código de módulo; el prefijo `RN-` frente a `RNF-` lo desambigua de la categoría de requerimiento no funcional.
+- **Las historias de usuario quedan fuera de la trazabilidad.** El documento de historias sirve para levantar requerimientos, pero la cadena trazable es `RF` → tripleta → Pull Request → código → prueba (Art. III.1). Una historia no equivale a un requerimiento funcional: suele originar varios.
 - **No existe un identificador de especificación.** Al corresponder cada tripleta a exactamente un requerimiento (Art. I.2), un `SPEC-SP-001` solo podría referirse a `RF-SP-001`: serían dos identificadores para la misma cosa, y el segundo acabaría desincronizándose. La tripleta se referencia por su ruta: `docs/specs/sp/001-registrar-rol/`.
 
 ### 3.2 Categorías de requerimientos no funcionales
@@ -120,3 +122,4 @@ El inventario y el estado de los módulos se consultan en [`modules.md` §4](mod
 | 0.1.0 | 20-08-2026 | Creación inicial con catálogo de módulos y matriz de trazabilidad. | Responsable técnico |
 | 0.2.0 | 20-08-2026 | El inventario de módulos se traslada a `modules.md`, que pasa a ser su autoridad única. Este documento conserva nomenclatura y trazabilidad. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | Se retira el identificador `SPEC-[MÓDULO]-NNN` por redundante con el `RF`. La matriz refleja las tres compuertas de aprobación de la tripleta. | Responsable técnico |
+| 0.4.0 | 20-08-2026 | §3.1 documenta el espacio de reglas transversales `RN-SEG` y deja las historias de usuario fuera de la cadena de trazabilidad. | Responsable técnico |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `requirements.md` |
-| Versión | 0.4.0 |
+| Versión | 0.5.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -29,7 +29,7 @@ Cada módulo del inventario tiene su documento en `docs/requirements/`, redactad
 
 | Módulo | Documento | Estado |
 |---|---|---|
-| `SP` — Sistema Principal | `requirements/sp.md` | Pendiente de redactar |
+| `SP` — Sistema Principal | [`requirements/sp.md`](requirements/sp.md) | **Aprobado** |
 | `USR` — Usuarios | `requirements/usr.md` | Pendiente de redactar |
 
 Para agregar un módulo nuevo, seguir el procedimiento de [`modules.md` §8](modules.md#8-como-se-incorpora-un-modulo).
@@ -84,7 +84,28 @@ Implementa el Art. III.1. Se actualiza **como parte del cambio**, no después (A
 
 | ID | Requerimiento | Módulo | Tripleta | Issue | PR | Pruebas | Estado |
 |---|---|---|---|---|---|---|---|
-| — | *(sin requerimientos registrados)* | — | — | — | — | — | — |
+| `RF-SP-001` | Registrar rol | `SP` | `specs/sp/001-registrar-rol/` | — | — | — | Pendiente |
+| `RF-SP-002` | Consultar roles | `SP` | `specs/sp/002-consultar-roles/` | — | — | — | Pendiente |
+| `RF-SP-003` | Consultar detalle de un rol | `SP` | `specs/sp/003-consultar-detalle-rol/` | — | — | — | Pendiente |
+| `RF-SP-004` | Editar rol | `SP` | `specs/sp/004-editar-rol/` | — | — | — | Pendiente |
+| `RF-SP-005` | Asignar permisos a un rol | `SP` | `specs/sp/005-asignar-permisos/` | — | — | — | Pendiente |
+| `RF-SP-006` | Revocar permisos de un rol | `SP` | `specs/sp/006-revocar-permisos/` | — | — | — | Pendiente |
+| `RF-SP-007` | Cambiar el estado de un rol | `SP` | `specs/sp/007-cambiar-estado-rol/` | — | — | — | Pendiente |
+| `RF-SP-008` | Cambiar el rol padre de un rol | `SP` | `specs/sp/008-cambiar-rol-padre/` | — | — | — | Pendiente |
+| `RF-SP-009` | Eliminar rol | `SP` | `specs/sp/009-eliminar-rol/` | — | — | — | Pendiente |
+| `RF-SP-010` | Consultar catálogo de permisos | `SP` | `specs/sp/010-consultar-permisos/` | — | — | — | Pendiente |
+| `RF-SP-011` | Consultar auditoría de cambios | `SP` | `specs/sp/011-consultar-auditoria-cambios/` | — | — | — | Pendiente |
+| `RF-SP-012` | Consultar auditoría de eliminación | `SP` | `specs/sp/012-consultar-auditoria-eliminacion/` | — | — | — | Pendiente |
+| `RF-SP-013` | Consultar auditoría de error | `SP` | `specs/sp/013-consultar-auditoria-error/` | — | — | — | Pendiente |
+| `RF-SP-014` | Consultar auditoría de seguridad | `SP` | `specs/sp/014-consultar-auditoria-seguridad/` | — | — | — | Pendiente |
+| `RF-SP-015` | Consultar detalle de un permiso | `SP` | `specs/sp/015-consultar-detalle-permiso/` | — | — | — | Pendiente |
+| `RF-SP-016` | Registrar membresía | `SP` | `specs/sp/016-registrar-membresia/` | — | — | — | Pendiente |
+| `RF-SP-017` | Consultar membresías | `SP` | `specs/sp/017-consultar-membresias/` | — | — | — | Pendiente |
+| `RF-SP-018` | Consultar detalle de una membresía | `SP` | `specs/sp/018-consultar-detalle-membresia/` | — | — | — | Pendiente |
+| `RF-SP-019` | Consultar monedas | `SP` | `specs/sp/019-consultar-monedas/` | — | — | — | Pendiente |
+| `RF-SP-020` | Registrar país | `SP` | `specs/sp/020-registrar-pais/` | — | — | — | Pendiente |
+| `RF-SP-021` | Consultar países | `SP` | `specs/sp/021-consultar-paises/` | — | — | — | Pendiente |
+
 
 **Estados**, que reflejan las tres compuertas del Art. I.6:
 
@@ -107,9 +128,11 @@ Un requerimiento solo pasa a `Implementado` cuando cumple **todas** las condicio
 
 | Indicador | Valor |
 |---|---|
-| Requerimientos registrados | 0 |
+| Requerimientos registrados | 21 |
 | Requerimientos especificados | 0 |
 | Requerimientos implementados | 0 |
+
+Los 21 corresponden al módulo `SP`. Ninguno ha superado la primera compuerta del Art. I.6: no existe todavía ninguna `spec.md`.
 
 El inventario y el estado de los módulos se consultan en [`modules.md` §4](modules.md#4-inventario-de-modulos).
 
@@ -123,3 +146,4 @@ El inventario y el estado de los módulos se consultan en [`modules.md` §4](mod
 | 0.2.0 | 20-08-2026 | El inventario de módulos se traslada a `modules.md`, que pasa a ser su autoridad única. Este documento conserva nomenclatura y trazabilidad. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | Se retira el identificador `SPEC-[MÓDULO]-NNN` por redundante con el `RF`. La matriz refleja las tres compuertas de aprobación de la tripleta. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | §3.1 documenta el espacio de reglas transversales `RN-SEG` y deja las historias de usuario fuera de la cadena de trazabilidad. | Responsable técnico |
+| 0.5.0 | 20-08-2026 | Se registran en la matriz los 21 requerimientos del módulo `SP`, cuyo documento queda aprobado. | Responsable técnico |

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -5,13 +5,13 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `requirements.md` |
-| Versión | 0.2.0 |
+| Versión | 0.3.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
 | Última actualización | 20-08-2026 |
-| Documento superior | `constitution.md` v0.3.0 |
-| Documentos relacionados | `modules.md` v0.1.0 |
+| Documento superior | `constitution.md` v0.5.0 |
+| Documentos relacionados | `modules.md` v0.3.0 |
 
 ---
 
@@ -47,7 +47,6 @@ Para agregar un módulo nuevo, seguir el procedimiento de [`modules.md` §8](mod
 | Regla de negocio | `RN-[MÓDULO]-NNN` | `RN-SP-003` |
 | Criterio de aceptación | `CA-[MÓDULO]-NNN` | `CA-SP-001` |
 | Validación | `VAL-NNN` | `VAL-001` |
-| Especificación | `SPEC-[MÓDULO]-NNN` | `SPEC-SP-001` |
 | Prueba | `T-[MÓDULO]-NNN` | `T-SP-001` |
 
 Reglas:
@@ -55,6 +54,7 @@ Reglas:
 - La numeración es correlativa **dentro de cada módulo** y **nunca se reutiliza**, ni siquiera si el requerimiento se descarta. Un identificador retirado se marca como `Descartado` en la matriz y su número queda consumido.
 - Los submódulos **no** intervienen en el identificador ([`modules.md` §2.2](modules.md#22-por-que-los-submodulos-no-llevan-codigo-propio)): mover una funcionalidad entre submódulos no debe cambiar su identificador.
 - El código de módulo, una vez usado en un identificador, **no se cambia jamás**.
+- **No existe un identificador de especificación.** Al corresponder cada tripleta a exactamente un requerimiento (Art. I.2), un `SPEC-SP-001` solo podría referirse a `RF-SP-001`: serían dos identificadores para la misma cosa, y el segundo acabaría desincronizándose. La tripleta se referencia por su ruta: `docs/specs/sp/001-registrar-rol/`.
 
 ### 3.2 Categorías de requerimientos no funcionales
 
@@ -80,11 +80,22 @@ Las categorías **no son módulos**: comparten el espacio de nombres pero clasif
 
 Implementa el Art. III.1. Se actualiza **como parte del cambio**, no después (Art. III.6).
 
-| ID | Requerimiento | Módulo | Especificación | Issue | PR | Pruebas | Estado |
+| ID | Requerimiento | Módulo | Tripleta | Issue | PR | Pruebas | Estado |
 |---|---|---|---|---|---|---|---|
 | — | *(sin requerimientos registrados)* | — | — | — | — | — | — |
 
-**Estados:** `Pendiente` · `Especificado` · `En desarrollo` · `En revisión` · `Implementado` · `Descartado`.
+**Estados**, que reflejan las tres compuertas del Art. I.6:
+
+| Estado | Significa |
+|---|---|
+| `Pendiente` | Registrado, sin `spec.md` |
+| `Spec en revisión` | `spec.md` escrita, en su Pull Request |
+| `Spec aprobada` | Compuerta 1 superada; puede escribirse `plan.md` |
+| `Plan aprobado` | Compuerta 2 superada; pueden escribirse las tareas |
+| `Tasks aprobadas` | Compuerta 3 superada; puede escribirse código |
+| `En desarrollo` | Implementación en curso |
+| `Implementado` | Integrado y con la definición de terminado cumplida |
+| `Descartado` | Retirado; su número queda consumido |
 
 Un requerimiento solo pasa a `Implementado` cuando cumple **todas** las condiciones de la definición de terminado (§16 de la constitución).
 
@@ -108,3 +119,4 @@ El inventario y el estado de los módulos se consultan en [`modules.md` §4](mod
 |---|---|---|---|
 | 0.1.0 | 20-08-2026 | Creación inicial con catálogo de módulos y matriz de trazabilidad. | Responsable técnico |
 | 0.2.0 | 20-08-2026 | El inventario de módulos se traslada a `modules.md`, que pasa a ser su autoridad única. Este documento conserva nomenclatura y trazabilidad. | Responsable técnico |
+| 0.3.0 | 20-08-2026 | Se retira el identificador `SPEC-[MÓDULO]-NNN` por redundante con el `RF`. La matriz refleja las tres compuertas de aprobación de la tripleta. | Responsable técnico |

--- a/docs/requirements/.pages
+++ b/docs/requirements/.pages
@@ -1,0 +1,5 @@
+title: Requerimientos por módulo
+nav:
+  - Plantilla: plantilla.md
+  - Sistema Principal (SP): sp.md
+  - ...

--- a/docs/requirements/guides/001-sp.md
+++ b/docs/requirements/guides/001-sp.md
@@ -1,0 +1,58 @@
+Este documento servira como referencia para crear los requerimientos
+
+# submodulos
+---
+## Roles
+Permitir la gestion de roles en el sistema
+### Acciones
+1. Permitir crear
+2. Permitir consultar (en lista e individual)
+3. Permitir editar
+4. Permitit eliminar
+### Reglas
+* Como regla fundamental siempre debe de existir un usuario con rol Super Administrador
+* El super administrador sera el unico sin un rol
+* Todos los demas roles siempre estaran con un rol padre
+* Cada nombre de rol es unico siempre y cuando se tome en cuenta el eliminado logico
+* Se podra identificar que rol es funcionario de la empresa y que rol es consumidor del mismo
+---
+## Permisos
+Permitir la gestion de permisos que se encuentran en el sistema
+### Acciones
+1. Permitir consultar (en lista e individual)
+### Reglas
+* Solo se podran crear permisos desde base de datos
+* No se podran eliminar los permisos (Ni logico ni fisico)
+* No se podran editar los permisos
+---
+## Roles y permisos
+Permitir la asociacion de permisos y roles
+### Acciones
+1. Permitir asociar un rol y con un permiso
+### Reglas
+* Solo se podran asociar los permisos a los que el rol padre tenga acceso
+* El super administrador tendra acceso a todos los permisos
+* En caso de quitar un permiso, no es necesario suministrar el motivo, en la auditoria se colocar un mensaje diciendo que se quito
+---
+## Membresia
+`Subcategoria para los roles`
+Saber en que nivel se encuentra cada cliente para accesos a diferentes servicios del sistema (Aun si se puede ver cursos hay cursos para los vips y otros para todos)
+### Acciones
+1. Permitir crear nuevas membresias para ciertos roles
+2. Permitir consultar (en lista e individual)
+### Reglas
+* Cada membresia estara sujeta a una membresia de mayor nivel
+* Solo la membresia top estara libre de una membresia de mayor nivel
+* Al crear se seleccionara directamente cual es la membresia hija y se actualizara el orden de la jerarquia
+* No se podran eliminar o editar las membresias (Solo en el caso de crear que hay que actualizar el orden de la jerarquia)
+## Moneda
+`De momento solo USD pero es para poder escalar a futuro`
+Permitir la escala de diferentes monedas en el futuro
+### Acciones
+1. Permitir consultar (en lista)
+## Paises
+### Acciones
+1. Permitir crear
+2. Permitir consular (en lista)
+### Reglas
+* Los paises no se podran eliminar ni editar

--- a/docs/requirements/plantilla.md
+++ b/docs/requirements/plantilla.md
@@ -17,6 +17,14 @@
 
     Este documento responde *«qué requerimientos tiene el módulo»*; la tripleta responde *«cómo se comporta cada uno»*.
 
+!!! abstract "Secciones que migraron a la tripleta"
+
+    Esta plantilla sustituye a `PlantillaRequerimientos_Modulo.docx`, escrita cuando cada funcionalidad tenía una sola especificación. Al adoptarse la tripleta (Art. I), las siguientes secciones se trasladaron a `spec.md`, donde se documentan **por requerimiento**:
+
+    Precondiciones · Postcondiciones · Flujo principal · Flujos alternativos (`FA-`) · Excepciones (`EX-`) · Datos de entrada y salida · Validaciones (`VAL-`) · Criterios de aceptación (`CA-`)
+
+    Todo lo demás de la plantilla original se conserva aquí, porque es de alcance modular y no cabe en una tripleta.
+
 ---
 
 ## 1. Información del módulo
@@ -61,9 +69,11 @@ Según [`modules.md` §5](../modules.md).
 
 ## 5. Reglas de negocio
 
-| ID | Regla | Detalle en |
-|---|---|---|
-| `RN-COD-001` | [Enunciado] | [Documento] |
+| ID | Regla | Cuándo aplica | Qué debe ocurrir | Prioridad |
+|---|---|---|---|---|
+| `RN-COD-001` | [Nombre corto] | [Condición que la dispara] | [Comportamiento exigido] | Crítica / Alta / Media / Baja |
+
+Si las reglas ya están definidas en otro documento, **se referencian con una columna «aplica a»** en lugar de repetirlas. Dos copias de una regla acaban divergiendo.
 
 ## 6. Requerimientos funcionales
 
@@ -118,6 +128,25 @@ El contrato detallado de cada endpoint se define en el `plan.md` de su tripleta.
 | Entidad | Descripción | Dueño |
 |---|---|---|
 | `tabla` | [Qué guarda] | Este módulo |
+
+### 10.1 Campos principales — `tabla`
+
+| Campo | Tipo | PK | FK | Nullable | Default | Entidad relacional |
+|---|---|---|---|---|---|---|
+| `id` | `uuid` | Sí | No | No | — | — |
+| `[campo]` | `[tipo]` | No | No | Sí / No | `[default]` | `[entidad]` |
+| `created_at` | `timestamptz` | No | No | No | `now()` | — |
+| `updated_at` | `timestamptz` | No | No | No | `now()` | — |
+
+Sin columnas de actor: quién creó o editó el registro reside en la auditoría (Art. V.7).
+
+### 10.2 Restricciones exigidas en el esquema
+
+| Restricción | Sobre | Regla que implementa |
+|---|---|---|
+| `uq_<tabla>_<columna>` | `tabla(columna)` | `RN-COD-NNN` |
+
+Se declaran en la base de datos, no solo en Java (Art. V.6). Las reglas que no sean expresables de forma declarativa se verifican en el dominio y exigen prueba unitaria propia; conviene decirlo explícitamente.
 
 El esquema exacto vive en las migraciones Flyway, que son su fuente de verdad (Art. V.3).
 

--- a/docs/requirements/plantilla.md
+++ b/docs/requirements/plantilla.md
@@ -101,13 +101,7 @@ Si las reglas ya están definidas en otro documento, **se referencian con una co
 | Tripleta | `docs/specs/<mod>/NNN-<nombre>/` |
 | Estado | Pendiente |
 
-[Descripción del requerimiento: qué debe permitir hacer el sistema. Dos o tres frases.]
-
-!!! tip "Dónde va el resto"
-
-    **Precondiciones, postcondiciones, flujo principal, flujos alternativos, excepciones, datos de entrada y salida, validaciones y criterios de aceptación** se documentan en el `spec.md` de la tripleta de este requerimiento.
-
-    Los **datos que el módulo persiste** sí van aquí, en §10: son de alcance modular y no cambian con cada requerimiento.
+[Descripción del requerimiento: qué debe permitir hacer el sistema. Dos o tres frases. El comportamiento detallado va en `spec.md`.]
 
 ## 7. Requerimientos no funcionales
 

--- a/docs/requirements/plantilla.md
+++ b/docs/requirements/plantilla.md
@@ -101,7 +101,13 @@ Si las reglas ya están definidas en otro documento, **se referencian con una co
 | Tripleta | `docs/specs/<mod>/NNN-<nombre>/` |
 | Estado | Pendiente |
 
-[Descripción del requerimiento: qué debe permitir hacer el sistema. Dos o tres frases. El comportamiento detallado va en `spec.md`.]
+[Descripción del requerimiento: qué debe permitir hacer el sistema. Dos o tres frases.]
+
+!!! tip "Dónde va el resto"
+
+    **Precondiciones, postcondiciones, flujo principal, flujos alternativos, excepciones, datos de entrada y salida, validaciones y criterios de aceptación** se documentan en el `spec.md` de la tripleta de este requerimiento.
+
+    Los **datos que el módulo persiste** sí van aquí, en §10: son de alcance modular y no cambian con cada requerimiento.
 
 ## 7. Requerimientos no funcionales
 

--- a/docs/requirements/plantilla.md
+++ b/docs/requirements/plantilla.md
@@ -1,0 +1,128 @@
+# Requerimientos del Módulo — `COD` [Nombre del módulo]
+
+| Campo | Valor |
+|---|---|
+| Módulo | `COD` — [Nombre] |
+| Versión | 0.1.0 |
+| Estado | Borrador · En revisión · **Aprobado** |
+| Responsable | [Nombre] |
+| Fecha de creación | [DD-MM-AAAA] |
+| Última actualización | [DD-MM-AAAA] |
+
+!!! info "Qué va en este documento"
+
+    **El catálogo de requerimientos del módulo:** qué debe hacer, bajo qué reglas de negocio y con qué permisos.
+
+    **El detalle de cada requerimiento no va aquí.** Flujos, validaciones, criterios de aceptación y casos límite viven en la tripleta de ese requerimiento (`docs/specs/<módulo>/<NNN>-<nombre>/`). Repetirlos aquí crearía dos fuentes que se contradicen.
+
+    Este documento responde *«qué requerimientos tiene el módulo»*; la tripleta responde *«cómo se comporta cada uno»*.
+
+---
+
+## 1. Información del módulo
+
+### 1.1 Descripción
+
+[Qué es el módulo, en dos o tres frases.]
+
+### 1.2 Objetivo
+
+[Qué necesidad del negocio resuelve.]
+
+### 1.3 Alcance
+
+**Incluye**
+
+- [Funcionalidad]
+
+**No incluye**
+
+- [Funcionalidad fuera de alcance, y a qué módulo pertenece]
+
+## 2. Submódulos
+
+Según [`modules.md` §5](../modules.md).
+
+| Submódulo | Responsabilidad | Requerimientos |
+|---|---|---|
+| [Nombre] | [Qué hace] | `RF-COD-001`, … |
+
+## 3. Dependencias
+
+| Módulo | Tipo | Para qué |
+|---|---|---|
+| [Módulo] | Consume | [Qué necesita de él] |
+
+## 4. Actores
+
+| Actor | Rol en el módulo | Permisos típicos |
+|---|---|---|
+| [Actor] | [Qué hace] | `recurso:acción` |
+
+## 5. Reglas de negocio
+
+| ID | Regla | Detalle en |
+|---|---|---|
+| `RN-COD-001` | [Enunciado] | [Documento] |
+
+## 6. Requerimientos funcionales
+
+### 6.1 Resumen
+
+| ID | Requerimiento | Prioridad | Permiso | Estado |
+|---|---|---|---|---|
+| `RF-COD-001` | [Nombre] | Crítica | `recurso:acción` | Pendiente |
+
+**Prioridades:** Crítica · Alta · Media · Baja.
+**Estados:** los de [`requirements.md` §4](../requirements.md).
+
+### 6.2 Fichas
+
+#### `RF-COD-001` — [Nombre]
+
+| Campo | Valor |
+|---|---|
+| Objetivo | [Qué necesidad satisface] |
+| Actor | [Quién lo ejecuta] |
+| Permiso requerido | `recurso:acción` |
+| Prioridad | Crítica / Alta / Media / Baja |
+| Reglas aplicables | `RN-COD-001` |
+| Depende de | `RF-COD-NNN` o — |
+| Tripleta | `docs/specs/<mod>/NNN-<nombre>/` |
+| Estado | Pendiente |
+
+[Descripción del requerimiento: qué debe permitir hacer el sistema. Dos o tres frases. El comportamiento detallado va en `spec.md`.]
+
+## 7. Requerimientos no funcionales
+
+| ID | Requerimiento | Detalle en |
+|---|---|---|
+| `RNF-CAT-001` | [Enunciado] | [Documento] |
+
+## 8. Integraciones
+
+| Sistema o módulo | Tipo | Dirección | Descripción |
+|---|---|---|---|
+| [Sistema] | REST | Entrada / Salida | [Para qué] |
+
+## 9. API
+
+| Método | Ruta | Requerimiento | Permiso |
+|---|---|---|---|
+| `GET` | `/api/v1/[recurso]` | `RF-COD-001` | `recurso:read` |
+
+El contrato detallado de cada endpoint se define en el `plan.md` de su tripleta.
+
+## 10. Persistencia
+
+| Entidad | Descripción | Dueño |
+|---|---|---|
+| `tabla` | [Qué guarda] | Este módulo |
+
+El esquema exacto vive en las migraciones Flyway, que son su fuente de verdad (Art. V.3).
+
+## 11. Control de cambios
+
+| Versión | Fecha | Cambio | Responsable |
+|---|---|---|---|
+| 0.1.0 | [DD-MM-AAAA] | Creación inicial. | [Nombre] |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -4,7 +4,7 @@
 |---|---|
 | Módulo | `SP` — Sistema Principal |
 | Paquete | `modules/system` |
-| Versión | 0.2.0 |
+| Versión | 0.3.0 |
 | Estado | **Borrador** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -66,14 +66,52 @@ Ninguna. `SP` es la raíz del grafo y debe seguir siéndolo: si llegara a depend
 
 ## 4. Actores
 
-| Actor | Rol en el módulo | Permisos típicos |
-|---|---|---|
-| Administrador | Define roles y su alcance de permisos | `roles:*`, `permissions:read` |
-| Auditor de negocio | Revisa qué cambió y qué se eliminó | `audit:read-changes`, `audit:read-deletions` |
-| Soporte técnico | Diagnostica fallos | `audit:read-errors` |
-| Responsable de seguridad | Revisa el control de acceso | los cuatro permisos de auditoría |
+Los actores de este módulo son los **roles del sistema**, definidos en la Épica 2 del documento de historias de usuario (HU08 a HU14).
+
+| Actor | Origen | Rol en este módulo | Permisos de `SP` |
+|---|---|---|---|
+| Administrador | HU08 | Define roles, su alcance de permisos y la configuración | `roles:*`, `permissions:read`, los cuatro de auditoría |
+| Contabilidad | HU09 | Consume roles; no los administra | `audit:read-changes`, `audit:read-deletions` |
+| Manager | HU10 | Consume roles; no los administra | — |
+| Director | HU11 | Consume roles; no los administra | — |
+| Agente o vendedor | HU12 | Consume roles; no los administra | — |
+| Estudiante | HU13 | Consume roles; no los administra | — |
+| Líder académico | HU14 | Consume roles; no los administra | — |
+
+Solo el **Administrador** opera sobre `SP`. Los demás roles aparecen aquí porque son los sujetos que `SP` define, no porque ejecuten sus requerimientos.
 
 Los permisos de auditoría se conceden por separado: los cuatro registros no tienen la misma sensibilidad y no se leen en bloque ([`security.md` §4.4](../security.md)).
+
+### 4.1 Catálogo inicial de roles del sistema
+
+Propuesta de códigos y de jerarquía de **contención de privilegios** (`RN-SEG-003`). Cierra parcialmente la decisión D-17.
+
+| Código | Nombre | HU | Rol padre | `is_system` |
+|---|---|---|---|---|
+| `SUPERADMIN` | Superadministrador | — | — | Sí |
+| `ADMIN` | Administrador | HU08 | `SUPERADMIN` | Sí |
+| `CONTABILIDAD` | Contabilidad | HU09 | `ADMIN` | Sí |
+| `LIDER_ACADEMICO` | Líder académico | HU14 | `ADMIN` | Sí |
+| `MANAGER` | Manager | HU10 | `ADMIN` | Sí |
+| `DIRECTOR` | Director | HU11 | `MANAGER` | Sí |
+| `AGENTE` | Agente o vendedor | HU12 | `DIRECTOR` | Sí |
+| `ESTUDIANTE` | Estudiante | HU13 | `ADMIN` | Sí |
+
+!!! danger "Dos jerarquías distintas que NO deben confundirse"
+
+    La columna «Rol padre» de esta tabla es **contención de privilegios**: acota qué permisos puede declarar cada rol (`RN-SEG-003`). Es una relación **rol → rol**.
+
+    La cadena comercial **manager → director → agente** de HU10, HU11 y HU12 es otra cosa: una relación **persona → persona** que determina **de quién** puede ver los datos cada uno.
+
+    Los tres roles piden el **mismo permiso** (`commissions:read`); lo que cambia es el conjunto de datos. Modelar la red comercial en `roles.parent_role_id` sería un error: esa columna no acota datos, y además relaciona roles, no usuarios. La red comercial necesita su propia estructura, en `USR` o en un módulo de red comercial.
+
+    Que ambas jerarquías coincidan en forma es una casualidad de este dominio, no una equivalencia.
+
+!!! warning "Requiere confirmación"
+
+    - **¿`ADMIN` contiene realmente a `CONTABILIDAD`?** La contención exige que `ADMIN` posea **todos** los permisos financieros. HU08 menciona pagos y comisiones, pero no retiros, balances ni egresos. Si el negocio quiere que Contabilidad pueda algo que Administración no, `CONTABILIDAD` debe colgar de `SUPERADMIN`, no de `ADMIN`.
+    - **¿`ADMIN` es el rol raíz, o existe `SUPERADMIN` por encima?** HU08 dice «acceso completo», y `RN-SEG-007` exige exactamente un rol raíz. Si `ADMIN` fuera la raíz, no habría quién lo cree ni quién lo acote.
+    - **HU14 tiene el actor cambiado:** está redactada desde el administrador que asigna el rol, no desde el líder académico. Esa funcionalidad pertenece a `USR`; falta la historia del líder académico desde su propia perspectiva.
 
 ## 5. Reglas de negocio
 
@@ -460,3 +498,4 @@ Definidos en [`architecture.md` §6.6](../architecture.md), que detalla el núcl
 |---|---|---|---|
 | 0.1.0 | 20-08-2026 | Creación inicial. 14 requerimientos funcionales derivados de `security.md` y `modules.md`. | Responsable técnico |
 | 0.2.0 | 20-08-2026 | §10 incorpora los campos principales y las restricciones del esquema, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |
+| 0.3.0 | 20-08-2026 | §4 registra los siete roles reales de la Épica 2 (HU08–HU14) y propone su jerarquía de contención. Se advierte la distinción entre contención de privilegios y jerarquía comercial. | Responsable técnico |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -4,11 +4,12 @@
 |---|---|
 | Módulo | `SP` — Sistema Principal |
 | Paquete | `modules/system` |
-| Versión | 0.7.0 |
-| Estado | **Borrador** |
+| Versión | 1.0.0 |
+| Estado | **Aprobado** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
 | Última actualización | 20-08-2026 |
+| Fecha de aprobación | 20-08-2026 |
 
 !!! info "Qué va en este documento"
 
@@ -738,3 +739,4 @@ Definidos en [`architecture.md` §6.6](../architecture.md), que detalla el núcl
 | 0.5.0 | 20-08-2026 | Se cierran los puntos abiertos: `SUPERADMIN` queda documentado como rol técnico y `ADMIN` como máximo rol de negocio, la convención `RN-SEG` frente a `RN-SP` queda resuelta, y la unicidad de hija de las membresías se garantiza en el esquema. | Responsable técnico |
 | 0.6.0 | 20-08-2026 | `role_type` pasa a tres valores con `VENDEDOR`, y los roles vendedores declaran `sales_rank` para ordenar el mando dentro de la fuerza comercial. Nuevas reglas `RN-SP-011` y `RN-SP-012`. | Responsable técnico |
 | 0.7.0 | 20-08-2026 | Se retira `sales_rank`: el orden de mando comercial se expresa con `parent_role_id`, el mismo campo que acota los permisos. `RN-SP-011` se reescribe y `RN-SP-012` queda retirada, con su número consumido. | Responsable técnico |
+| 1.0.0 | 20-08-2026 | Primera versión aprobada. Los 21 requerimientos quedan registrados en la matriz de trazabilidad. | Responsable técnico |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -4,7 +4,7 @@
 |---|---|
 | Módulo | `SP` — Sistema Principal |
 | Paquete | `modules/system` |
-| Versión | 0.5.0 |
+| Versión | 0.6.0 |
 | Estado | **Borrador** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -153,7 +153,9 @@ Reglas que no son transversales de seguridad y por tanto sí llevan el prefijo d
 |---|---|---|---|---|
 | `RN-SP-001` | Superadministrador siempre presente | Al eliminar o desactivar un usuario, o al retirarle el rol | Debe existir siempre al menos un usuario con rol `SUPERADMIN`; la operación que dejaría al sistema sin ninguno se rechaza | **Crítica** |
 | `RN-SP-002` | Rol padre obligatorio | Al crear o editar un rol | Todo rol declara un rol padre, salvo `SUPERADMIN`, que es el único sin él | Alta |
-| `RN-SP-003` | Clasificación del rol | Al crear un rol | Todo rol se clasifica como `FUNCIONARIO` (personal de la empresa) o `CONSUMIDOR` (cliente del sistema) | Alta |
+| `RN-SP-003` | Clasificación del rol | Al crear un rol | Todo rol se clasifica como `FUNCIONARIO` (personal interno), `VENDEDOR` (personal de la fuerza comercial) o `CONSUMIDOR` (cliente del sistema) | Alta |
+| `RN-SP-011` | Rango solo para vendedores | Al crear un rol | Un rol `VENDEDOR` declara obligatoriamente su rango dentro de la fuerza comercial; los roles `FUNCIONARIO` y `CONSUMIDOR` no lo declaran, y hacerlo se rechaza | Alta |
+| `RN-SP-012` | Rango único | Al crear un rol `VENDEDOR` | Dos roles vendedores no pueden compartir el mismo rango: el orden de mando debe quedar sin ambigüedad | Alta |
 | `RN-SP-004` | Permisos inmutables por API | Siempre | Los permisos no se crean, editan ni eliminan por la API: se pueblan y modifican únicamente por migración | Alta |
 | `RN-SP-005` | Revocación sin motivo | Al retirar un permiso de un rol | La fila de asociación se elimina físicamente y se audita en `audit_deletion_log` sin motivo declarado (Art. V.13, excepción de asociaciones) | Alta |
 | `RN-SP-006` | Membresía acotada por nivel | Al crear una membresía | Toda membresía está sujeta a una de mayor nivel; solo la membresía superior queda libre de ella | Alta |
@@ -208,12 +210,14 @@ Reglas que no son transversales de seguridad y por tanto sí llevan el prefijo d
 | Actor | Administrador |
 | Permiso requerido | `roles:create` |
 | Prioridad | Crítica |
-| Reglas aplicables | `RN-SEG-001`, `RN-SEG-003`, `RN-SEG-007`, `RN-SEG-010` |
+| Reglas aplicables | `RN-SEG-001`, `RN-SEG-003`, `RN-SEG-007`, `RN-SEG-010`, `RN-SP-002`, `RN-SP-003`, `RN-SP-011`, `RN-SP-012` |
 | Depende de | `RF-SP-010` |
 | Tripleta | `docs/specs/sp/001-registrar-rol/` |
 | Estado | Pendiente |
 
-El sistema debe permitir a un usuario autorizado registrar un rol con su código, nombre, descripción, rol padre y conjunto inicial de permisos. Los permisos declarados quedan acotados por los del rol padre y por los del propio actor que lo crea.
+El sistema debe permitir a un usuario autorizado registrar un rol con su código, nombre, descripción, clasificación, rol padre y conjunto inicial de permisos. Los permisos declarados quedan acotados por los del rol padre y por los del propio actor que lo crea.
+
+Si la clasificación es `VENDEDOR`, el alta exige además su **rango** dentro de la fuerza comercial, único entre los roles vendedores (`RN-SP-011`, `RN-SP-012`).
 
 #### `RF-SP-002` — Consultar roles
 
@@ -601,6 +605,7 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 | `name` | `varchar(100)` | No | No | No | — | — |
 | `description` | `text` | No | No | Sí | — | — |
 | `role_type` | `varchar(20)` | No | No | No | — | — |
+| `sales_rank` | `smallint` | No | No | Sí | — | — |
 | `parent_role_id` | `uuid` | No | Sí | Sí | — | `roles` |
 | `status` | `varchar(20)` | No | No | No | `ACTIVO` | — |
 | `is_system` | `boolean` | No | No | No | `false` | — |
@@ -610,7 +615,33 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 
 `parent_role_id` es nulo **únicamente** en el rol raíz (`RN-SEG-007`, `RN-SP-002`). No implica herencia: acota los privilegios del rol hijo (`security.md` §4.2).
 
-`role_type` distingue al personal de la empresa del cliente del sistema (`RN-SP-003`), con dominio cerrado `FUNCIONARIO` o `CONSUMIDOR`. De él depende, entre otras cosas, qué roles pueden asociarse a una membresía.
+`role_type` clasifica el rol con dominio cerrado (`RN-SP-003`):
+
+| Valor | Quién es |
+|---|---|
+| `FUNCIONARIO` | Personal interno de la empresa |
+| `VENDEDOR` | Personal de la fuerza comercial |
+| `CONSUMIDOR` | Cliente del sistema |
+
+De él depende, entre otras cosas, qué roles pueden asociarse a una membresía —solo los `CONSUMIDOR`— y cuáles declaran rango comercial.
+
+`sales_rank` ordena los roles de la fuerza comercial: menor valor, mayor mando. Es **obligatorio y único** en los roles `VENDEDOR` y **nulo** en los demás (`RN-SP-011`, `RN-SP-012`).
+
+!!! important "Por qué el rango es un campo aparte y no `parent_role_id`"
+
+    `parent_role_id` acota **permisos** (`RN-SEG-003`). `sales_rank` ordena **el mando**. Hoy coinciden —el agente tiene menos permisos *y* está más abajo—, pero son cosas distintas.
+
+    Si el mando se dedujera de `parent_role_id`, cambiar el alcance de permisos de un rol movería en silencio la cadena de mando, y al revés. El día que un rol comercial necesite un permiso que su superior no tenga, ambos usos quedarían enfrentados y no habría forma de expresarlo.
+
+    Un entero da además **orden total**, que es exactamente lo que «quién está por encima de quién» necesita, y deja a `parent_role_id` haciendo una sola cosa.
+
+!!! note "El rango ordena roles, no personas"
+
+    `sales_rank` establece que un director está por encima de un agente. **No** dice qué agentes tiene un director concreto: esa es una relación entre personas y forma parte de la estructura comercial, hoy aparcada.
+
+    Tampoco determina el alcance de datos, que sigue pendiente como **D-22**.
+
+    Queda además sin cubrir el **reordenamiento**: insertar un rango intermedio obligaría a desplazar los existentes, y ningún requerimiento lo contempla todavía.
 
 ### 10.3 Campos principales — `role_permissions`
 
@@ -677,7 +708,9 @@ Declaradas en la base de datos, no solo en Java (Art. V.6):
 | `uq_roles_name` | **Índice único parcial**: `roles(name) WHERE deleted_at IS NULL` — `RN-SEG-001` |
 | `fk_roles_parent` | `roles(parent_role_id)` → `roles(id)`, con restricción de eliminación — `RN-SEG-008` |
 | `ck_roles_status` | `roles(status)` en (`ACTIVO`, `INACTIVO`) — `RN-SEG-002` |
-| `ck_roles_type` | `roles(role_type)` en (`FUNCIONARIO`, `CONSUMIDOR`) — `RN-SP-003` |
+| `ck_roles_type` | `roles(role_type)` en (`FUNCIONARIO`, `VENDEDOR`, `CONSUMIDOR`) — `RN-SP-003` |
+| `ck_roles_sales_rank` | `(role_type = 'VENDEDOR') = (sales_rank IS NOT NULL)` — `RN-SP-011` |
+| `uq_roles_sales_rank` | **Índice único parcial**: `roles(sales_rank) WHERE sales_rank IS NOT NULL` — `RN-SP-012` |
 | `fk_role_permissions_roles` | `role_permissions(role_id)` → `roles(id)` |
 | `fk_role_permissions_permissions` | `role_permissions(permission_id)` → `permissions(id)` |
 | `fk_memberships_parent` | `memberships(parent_membership_id)` → `memberships(id)` — `RN-SP-006` |
@@ -713,3 +746,4 @@ Definidos en [`architecture.md` §6.6](../architecture.md), que detalla el núcl
 | 0.3.0 | 20-08-2026 | §4 registra los siete roles reales de la Épica 2 (HU08–HU14) y propone su jerarquía de contención. Se advierte la distinción entre contención de privilegios y jerarquía comercial. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | Se complementa con la guía `guides/001-sp.md`: tres submódulos nuevos (membresías, monedas, países), siete requerimientos, diez reglas propias `RN-SP-` y las consecuencias de esquema derivadas (unicidad parcial por borrado lógico y clasificación del rol). | Responsable técnico |
 | 0.5.0 | 20-08-2026 | Se cierran los puntos abiertos: `SUPERADMIN` queda documentado como rol técnico y `ADMIN` como máximo rol de negocio, la convención `RN-SEG` frente a `RN-SP` queda resuelta, y la unicidad de hija de las membresías se garantiza en el esquema. | Responsable técnico |
+| 0.6.0 | 20-08-2026 | `role_type` pasa a tres valores con `VENDEDOR`, y los roles vendedores declaran `sales_rank` para ordenar el mando dentro de la fuerza comercial. Nuevas reglas `RN-SP-011` y `RN-SP-012`. | Responsable técnico |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -1,0 +1,399 @@
+# Requerimientos del Módulo — `SP` Sistema Principal
+
+| Campo | Valor |
+|---|---|
+| Módulo | `SP` — Sistema Principal |
+| Paquete | `modules/system` |
+| Versión | 0.1.0 |
+| Estado | **Borrador** |
+| Responsable | Bonilla Diaz William Steven |
+| Fecha de creación | 20-08-2026 |
+| Última actualización | 20-08-2026 |
+
+!!! info "Qué va en este documento"
+
+    El catálogo de requerimientos del módulo: qué debe hacer, bajo qué reglas y con qué permisos.
+
+    El comportamiento detallado de cada requerimiento —flujos, validaciones, criterios de aceptación y casos límite— vive en su tripleta, en `docs/specs/sp/`. Aquí no se repite.
+
+---
+
+## 1. Información del módulo
+
+### 1.1 Descripción
+
+`SP` gobierna **quién puede hacer qué** en NEXUS y deja constancia de lo que ocurre. Administra el catálogo de permisos, la definición de roles con su contención de privilegios, y la consulta de los cuatro registros de auditoría.
+
+Es la raíz del grafo de dependencias: no depende de ningún módulo, y todos los demás dependen de él.
+
+### 1.2 Objetivo
+
+Permitir que la organización defina su estructura de autorización sin intervención de desarrollo. Crear un rol nuevo, o cambiar el alcance de uno existente, debe ser una operación administrativa y no un despliegue.
+
+### 1.3 Alcance
+
+**Incluye**
+
+- Consulta del catálogo de permisos.
+- Alta, consulta, edición, cambio de estado y eliminación de roles.
+- Asignación y revocación de permisos sobre un rol, con la contención respecto de su rol padre.
+- Consulta de los cuatro registros de auditoría, por separado y con permisos diferenciados.
+
+**No incluye**
+
+- Los usuarios, sus credenciales y su autenticación → módulo `USR`.
+- La asignación de roles a personas → módulo `USR`, porque su sujeto es el usuario y no el rol.
+- La **escritura** de los registros de auditoría: la emite cada módulo al ejecutar su operación. `SP` solo los consulta.
+
+## 2. Submódulos
+
+Según [`modules.md` §5.1](../modules.md).
+
+| Submódulo | Responsabilidad | Requerimientos |
+|---|---|---|
+| Permisos | Catálogo de permisos. Solo lectura por API; se pueblan por migración | `RF-SP-010` |
+| Roles | Alta, edición, estado, contención de privilegios y jerarquía | `RF-SP-001` a `RF-SP-009` |
+| Auditoría | Consulta de los cuatro registros | `RF-SP-011` a `RF-SP-014` |
+| Parámetros | Configuración transversal del sistema | *(sin requerimientos: alcance por definir)* |
+
+!!! warning "Submódulo Parámetros sin definir"
+
+    `modules.md` §5.1 registra este submódulo con sus entidades «por definir». Mientras no se le asignen requerimientos, el módulo `SP` no puede darse por completo.
+
+## 3. Dependencias
+
+Ninguna. `SP` es la raíz del grafo y debe seguir siéndolo: si llegara a depender de otro módulo aparecería un ciclo ([`modules.md` §7](../modules.md)).
+
+## 4. Actores
+
+| Actor | Rol en el módulo | Permisos típicos |
+|---|---|---|
+| Administrador | Define roles y su alcance de permisos | `roles:*`, `permissions:read` |
+| Auditor de negocio | Revisa qué cambió y qué se eliminó | `audit:read-changes`, `audit:read-deletions` |
+| Soporte técnico | Diagnostica fallos | `audit:read-errors` |
+| Responsable de seguridad | Revisa el control de acceso | los cuatro permisos de auditoría |
+
+Los permisos de auditoría se conceden por separado: los cuatro registros no tienen la misma sensibilidad y no se leen en bloque ([`security.md` §4.4](../security.md)).
+
+## 5. Reglas de negocio
+
+Las reglas de autorización están definidas en [`security.md` §4.3](../security.md) y **no se redefinen aquí**.
+
+| ID | Regla | Aplica a |
+|---|---|---|
+| `RN-SEG-001` | Código y nombre de rol únicos | `RF-SP-001`, `RF-SP-004` |
+| `RN-SEG-002` | Un rol `INACTIVO` no concede permisos aunque siga asignado | `RF-SP-007` |
+| `RN-SEG-003` | Los permisos de un rol son subconjunto de los de su padre | `RF-SP-005`, `RF-SP-008` |
+| `RN-SEG-004` | La validación se hace contra el padre inmediato, sin recorrer ancestros | `RF-SP-005` |
+| `RN-SEG-005` | Revocar un permiso se rechaza si un rol descendiente lo declara | `RF-SP-006` |
+| `RN-SEG-006` | La cadena de roles padre no admite ciclos | `RF-SP-008` |
+| `RN-SEG-007` | Existe exactamente un rol raíz sin padre | `RF-SP-001`, `RF-SP-008` |
+| `RN-SEG-008` | No se elimina un rol con hijos o con usuarios asignados | `RF-SP-009` |
+| `RN-SEG-010` | Nadie asigna permisos que no posee | `RF-SP-005` |
+| `RN-SEG-011` | Nadie modifica los permisos de un rol que tiene asignado | `RF-SP-004` a `RF-SP-009` |
+| `RN-SEG-012` | Los roles de sistema no se modifican ni eliminan por la API | `RF-SP-004` a `RF-SP-009` |
+| `RN-SEG-013` | Cambiar el rol padre revalida `RN-SEG-003` contra el nuevo padre | `RF-SP-008` |
+
+!!! danger "Punto abierto: prefijo de las reglas"
+
+    La nomenclatura de [`requirements.md` §3.1](../requirements.md) define las reglas de negocio como `RN-[MÓDULO]-NNN`, pero estas usan `RN-SEG-…`, y `SEG` **no es un código de módulo**: es una categoría de requerimiento no funcional.
+
+    Hay que decidir antes de que las reglas se referencien desde el código:
+
+    - **Renombrar** a `RN-SP-…` las que pertenecen a este módulo. Cumple la nomenclatura, pero `RN-SEG-009`, `010` y `011` abarcan también a `USR`, así que ninguna asignación es limpia.
+    - **Declarar `SEG` como espacio de reglas transversales de seguridad**, documentando la excepción en `requirements.md` §3.1.
+
+    Recomiendo la segunda: son reglas que cruzan módulos por naturaleza, y renombrarlas obligaría a partir tres de ellas.
+
+## 6. Requerimientos funcionales
+
+### 6.1 Resumen
+
+| ID | Requerimiento | Prioridad | Permiso | Estado |
+|---|---|---|---|---|
+| `RF-SP-001` | Registrar rol | Crítica | `roles:create` | Pendiente |
+| `RF-SP-002` | Consultar roles | Crítica | `roles:read` | Pendiente |
+| `RF-SP-003` | Consultar detalle de un rol | Alta | `roles:read` | Pendiente |
+| `RF-SP-004` | Editar rol | Alta | `roles:update` | Pendiente |
+| `RF-SP-005` | Asignar permisos a un rol | Crítica | `roles:update` | Pendiente |
+| `RF-SP-006` | Revocar permisos de un rol | Alta | `roles:update` | Pendiente |
+| `RF-SP-007` | Cambiar el estado de un rol | Alta | `roles:update` | Pendiente |
+| `RF-SP-008` | Cambiar el rol padre de un rol | Media | `roles:update` | Pendiente |
+| `RF-SP-009` | Eliminar rol | Media | `roles:delete` | Pendiente |
+| `RF-SP-010` | Consultar catálogo de permisos | Crítica | `permissions:read` | Pendiente |
+| `RF-SP-011` | Consultar auditoría de cambios | Media | `audit:read-changes` | Pendiente |
+| `RF-SP-012` | Consultar auditoría de eliminación | Media | `audit:read-deletions` | Pendiente |
+| `RF-SP-013` | Consultar auditoría de error | Media | `audit:read-errors` | Pendiente |
+| `RF-SP-014` | Consultar auditoría de seguridad | Alta | `audit:read-security` | Pendiente |
+
+**Orden sugerido de implementación:** `RF-SP-010` → `RF-SP-001` → `RF-SP-002` → `RF-SP-005` → el resto. El catálogo de permisos es prerrequisito de todo lo demás, y sin roles no hay nada que auditar.
+
+### 6.2 Fichas
+
+#### `RF-SP-001` — Registrar rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Permitir que la organización defina un rol nuevo sin desplegar código |
+| Actor | Administrador |
+| Permiso requerido | `roles:create` |
+| Prioridad | Crítica |
+| Reglas aplicables | `RN-SEG-001`, `RN-SEG-003`, `RN-SEG-007`, `RN-SEG-010` |
+| Depende de | `RF-SP-010` |
+| Tripleta | `docs/specs/sp/001-registrar-rol/` |
+| Estado | Pendiente |
+
+El sistema debe permitir a un usuario autorizado registrar un rol con su código, nombre, descripción, rol padre y conjunto inicial de permisos. Los permisos declarados quedan acotados por los del rol padre y por los del propio actor que lo crea.
+
+#### `RF-SP-002` — Consultar roles
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Ver qué roles existen y en qué estado |
+| Actor | Administrador |
+| Permiso requerido | `roles:read` |
+| Prioridad | Crítica |
+| Reglas aplicables | — |
+| Depende de | `RF-SP-001` |
+| Tripleta | `docs/specs/sp/002-consultar-roles/` |
+| Estado | Pendiente |
+
+Listado paginado de roles, con filtro por estado y por rol padre, y búsqueda por código o nombre. Toda colección se pagina (`architecture.md` §7.4).
+
+#### `RF-SP-003` — Consultar detalle de un rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Conocer el alcance exacto de un rol antes de asignarlo o modificarlo |
+| Actor | Administrador |
+| Permiso requerido | `roles:read` |
+| Prioridad | Alta |
+| Reglas aplicables | — |
+| Depende de | `RF-SP-001` |
+| Tripleta | `docs/specs/sp/003-consultar-detalle-rol/` |
+| Estado | Pendiente |
+
+Devuelve el rol con su lista explícita de permisos, su rol padre y sus roles hijos. Responde de un vistazo qué puede hacer alguien con ese rol, que es la ventaja de no usar herencia.
+
+#### `RF-SP-004` — Editar rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Corregir el nombre o la descripción de un rol |
+| Actor | Administrador |
+| Permiso requerido | `roles:update` |
+| Prioridad | Alta |
+| Reglas aplicables | `RN-SEG-001`, `RN-SEG-011`, `RN-SEG-012` |
+| Depende de | `RF-SP-001` |
+| Tripleta | `docs/specs/sp/004-editar-rol/` |
+| Estado | Pendiente |
+
+Modifica nombre y descripción. **No** modifica permisos, estado ni rol padre: cada una de esas operaciones tiene sus propias reglas y su propio requerimiento.
+
+#### `RF-SP-005` — Asignar permisos a un rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Ampliar lo que un rol puede hacer, sin exceder su cota |
+| Actor | Administrador |
+| Permiso requerido | `roles:update` |
+| Prioridad | Crítica |
+| Reglas aplicables | `RN-SEG-003`, `RN-SEG-004`, `RN-SEG-010`, `RN-SEG-011`, `RN-SEG-012` |
+| Depende de | `RF-SP-001`, `RF-SP-010` |
+| Tripleta | `docs/specs/sp/005-asignar-permisos/` |
+| Estado | Pendiente |
+
+Agrega permisos a un rol. La operación se rechaza si algún permiso no está contenido en el rol padre (`RN-SEG-003`) o en los permisos efectivos del actor (`RN-SEG-010`). Es el requerimiento donde se materializa el modelo de contención.
+
+#### `RF-SP-006` — Revocar permisos de un rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Reducir el alcance de un rol sin romper el invariante de contención |
+| Actor | Administrador |
+| Permiso requerido | `roles:update` |
+| Prioridad | Alta |
+| Reglas aplicables | `RN-SEG-005`, `RN-SEG-011`, `RN-SEG-012` |
+| Depende de | `RF-SP-005` |
+| Tripleta | `docs/specs/sp/006-revocar-permisos/` |
+| Estado | Pendiente |
+
+Retira permisos de un rol. Si algún rol descendiente declara el permiso que se retira, la operación **se rechaza** e informa qué roles lo impiden; el sistema no revoca en cascada de forma implícita (`RN-SEG-005`).
+
+#### `RF-SP-007` — Cambiar el estado de un rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Suspender un rol sin perder su definición ni sus asignaciones |
+| Actor | Administrador |
+| Permiso requerido | `roles:update` |
+| Prioridad | Alta |
+| Reglas aplicables | `RN-SEG-002`, `RN-SEG-011`, `RN-SEG-012` |
+| Depende de | `RF-SP-001` |
+| Tripleta | `docs/specs/sp/007-cambiar-estado-rol/` |
+| Estado | Pendiente |
+
+Activa o desactiva un rol. Un rol `INACTIVO` deja de conceder permisos de inmediato aunque siga asignado a usuarios (`RN-SEG-002`), lo que exige invalidar la caché de resolución (`security.md` §4.5).
+
+#### `RF-SP-008` — Cambiar el rol padre de un rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Reubicar un rol en la jerarquía de contención |
+| Actor | Administrador |
+| Permiso requerido | `roles:update` |
+| Prioridad | Media |
+| Reglas aplicables | `RN-SEG-003`, `RN-SEG-006`, `RN-SEG-007`, `RN-SEG-013` |
+| Depende de | `RF-SP-001` |
+| Tripleta | `docs/specs/sp/008-cambiar-rol-padre/` |
+| Estado | Pendiente |
+
+Reasigna el rol padre. Exige revalidar la contención contra el nuevo padre (`RN-SEG-013`) y verificar que no se forme un ciclo (`RN-SEG-006`).
+
+#### `RF-SP-009` — Eliminar rol
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Retirar un rol que dejó de tener sentido |
+| Actor | Administrador |
+| Permiso requerido | `roles:delete` |
+| Prioridad | Media |
+| Reglas aplicables | `RN-SEG-008`, `RN-SEG-011`, `RN-SEG-012` |
+| Depende de | `RF-SP-001` |
+| Tripleta | `docs/specs/sp/009-eliminar-rol/` |
+| Estado | Pendiente |
+
+Elimina un rol que no tenga roles hijos ni usuarios asignados (`RN-SEG-008`). La eliminación **exige motivo** y conserva el estado del registro (Art. V.13), por lo que el endpoint recibe el motivo en el cuerpo de la petición.
+
+#### `RF-SP-010` — Consultar catálogo de permisos
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Saber qué permisos existen para poder componer roles |
+| Actor | Administrador |
+| Permiso requerido | `permissions:read` |
+| Prioridad | Crítica |
+| Reglas aplicables | — |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/010-consultar-permisos/` |
+| Estado | Pendiente |
+
+Lista los permisos disponibles con su código, recurso, acción y descripción legible. El catálogo es **solo lectura por API**: se puebla y modifica por migración Flyway (`security.md` §4.4).
+
+#### `RF-SP-011` — Consultar auditoría de cambios
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Responder quién creó o editó un registro, y qué cambió |
+| Actor | Auditor de negocio, Responsable de seguridad |
+| Permiso requerido | `audit:read-changes` |
+| Prioridad | Media |
+| Reglas aplicables | — |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/011-consultar-auditoria-cambios/` |
+| Estado | Pendiente |
+
+Consulta paginada de `audit_change_log`, con filtro por módulo, entidad, identificador, actor y rango de fechas. Es la **única** fuente del actor de un cambio, porque las tablas de negocio no lo almacenan (Art. V.7).
+
+#### `RF-SP-012` — Consultar auditoría de eliminación
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Responder quién eliminó qué, por qué, y qué era lo eliminado |
+| Actor | Auditor de negocio, Responsable de seguridad |
+| Permiso requerido | `audit:read-deletions` |
+| Prioridad | Media |
+| Reglas aplicables | — |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/012-consultar-auditoria-eliminacion/` |
+| Estado | Pendiente |
+
+Consulta paginada de `audit_deletion_log`, incluyendo el motivo declarado y el estado del registro al momento de eliminarse.
+
+#### `RF-SP-013` — Consultar auditoría de error
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Diagnosticar a quién le falló qué, y sobre qué recurso |
+| Actor | Soporte técnico, Responsable de seguridad |
+| Permiso requerido | `audit:read-errors` |
+| Prioridad | Media |
+| Reglas aplicables | — |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/013-consultar-auditoria-error/` |
+| Estado | Pendiente |
+
+Consulta paginada de `audit_error_log`, con filtro por tipo de error, severidad, código y rango de fechas. El detalle técnico completo no está aquí: se alcanza por el identificador de correlación (`architecture.md` §6.6.4).
+
+#### `RF-SP-014` — Consultar auditoría de seguridad
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Revisar la actividad sobre el control de acceso |
+| Actor | Responsable de seguridad |
+| Permiso requerido | `audit:read-security` |
+| Prioridad | Alta |
+| Reglas aplicables | — |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/014-consultar-auditoria-seguridad/` |
+| Estado | Pendiente |
+
+Consulta paginada de `audit_security_log`, con filtro por tipo de evento, severidad, resultado y actor. Su permiso se concede aparte de los demás de auditoría (`security.md` §8).
+
+## 7. Requerimientos no funcionales
+
+Definidos en [`security.md` §11](../security.md) y en la constitución. Los que este módulo debe satisfacer:
+
+| ID | Requerimiento |
+|---|---|
+| `RNF-SEG-001` | Autenticación y autorización basada en roles y permisos |
+| `RNF-SEG-002` | Todo endpoint no declarado como público exige autenticación |
+| `RNF-SEG-006` | Los eventos de seguridad quedan registrados en `audit_security_log` |
+| `RNF-PERF-001` | Lectura p95 < 500 ms, escritura p95 < 1 s (Art. XV.9) |
+
+## 8. Integraciones
+
+Ninguna con sistemas externos. Internamente, `USR` consume de este módulo el catálogo de roles y la resolución de permisos efectivos, a través de la interfaz publicada por su capa `application` (`architecture.md` §5.3).
+
+## 9. API
+
+| Método | Ruta | Requerimiento | Permiso |
+|---|---|---|---|
+| `POST` | `/api/v1/roles` | `RF-SP-001` | `roles:create` |
+| `GET` | `/api/v1/roles` | `RF-SP-002` | `roles:read` |
+| `GET` | `/api/v1/roles/{id}` | `RF-SP-003` | `roles:read` |
+| `PATCH` | `/api/v1/roles/{id}` | `RF-SP-004` | `roles:update` |
+| `POST` | `/api/v1/roles/{id}/permissions` | `RF-SP-005` | `roles:update` |
+| `DELETE` | `/api/v1/roles/{id}/permissions` | `RF-SP-006` | `roles:update` |
+| `PATCH` | `/api/v1/roles/{id}/status` | `RF-SP-007` | `roles:update` |
+| `PATCH` | `/api/v1/roles/{id}/parent` | `RF-SP-008` | `roles:update` |
+| `DELETE` | `/api/v1/roles/{id}` | `RF-SP-009` | `roles:delete` |
+| `GET` | `/api/v1/permissions` | `RF-SP-010` | `permissions:read` |
+| `GET` | `/api/v1/audit/changes` | `RF-SP-011` | `audit:read-changes` |
+| `GET` | `/api/v1/audit/deletions` | `RF-SP-012` | `audit:read-deletions` |
+| `GET` | `/api/v1/audit/errors` | `RF-SP-013` | `audit:read-errors` |
+| `GET` | `/api/v1/audit/security` | `RF-SP-014` | `audit:read-security` |
+
+Rutas propuestas. El contrato exacto de cada una se fija en el `plan.md` de su tripleta.
+
+## 10. Persistencia
+
+| Entidad | Descripción | Dueño |
+|---|---|---|
+| `permissions` | Catálogo de permisos `recurso:acción` | `SP` |
+| `roles` | Roles, su estado y su rol padre | `SP` |
+| `role_permissions` | Permisos declarados por cada rol | `SP` |
+| `audit_change_log` | Auditoría de creación y edición | `SP` |
+| `audit_deletion_log` | Auditoría de eliminación | `SP` |
+| `audit_error_log` | Auditoría de fallos | `SP` |
+| `audit_security_log` | Auditoría de control de acceso | `SP` |
+
+Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` §6.6](../architecture.md). El esquema exacto vive en las migraciones Flyway, que son su fuente de verdad (Art. V.3).
+
+`SP` es dueño de las cuatro tablas de auditoría, pero **no es quien las escribe**: cada módulo emite sus propios eventos al ejecutar sus operaciones. `SP` publica la interfaz de escritura y es el único que las consulta por API.
+
+## 11. Control de cambios
+
+| Versión | Fecha | Cambio | Responsable |
+|---|---|---|---|
+| 0.1.0 | 20-08-2026 | Creación inicial. 14 requerimientos funcionales derivados de `security.md` y `modules.md`. | Responsable técnico |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -4,7 +4,7 @@
 |---|---|
 | Módulo | `SP` — Sistema Principal |
 | Paquete | `modules/system` |
-| Versión | 0.6.0 |
+| Versión | 0.7.0 |
 | Estado | **Borrador** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -154,8 +154,7 @@ Reglas que no son transversales de seguridad y por tanto sí llevan el prefijo d
 | `RN-SP-001` | Superadministrador siempre presente | Al eliminar o desactivar un usuario, o al retirarle el rol | Debe existir siempre al menos un usuario con rol `SUPERADMIN`; la operación que dejaría al sistema sin ninguno se rechaza | **Crítica** |
 | `RN-SP-002` | Rol padre obligatorio | Al crear o editar un rol | Todo rol declara un rol padre, salvo `SUPERADMIN`, que es el único sin él | Alta |
 | `RN-SP-003` | Clasificación del rol | Al crear un rol | Todo rol se clasifica como `FUNCIONARIO` (personal interno), `VENDEDOR` (personal de la fuerza comercial) o `CONSUMIDOR` (cliente del sistema) | Alta |
-| `RN-SP-011` | Rango solo para vendedores | Al crear un rol | Un rol `VENDEDOR` declara obligatoriamente su rango dentro de la fuerza comercial; los roles `FUNCIONARIO` y `CONSUMIDOR` no lo declaran, y hacerlo se rechaza | Alta |
-| `RN-SP-012` | Rango único | Al crear un rol `VENDEDOR` | Dos roles vendedores no pueden compartir el mismo rango: el orden de mando debe quedar sin ambigüedad | Alta |
+| `RN-SP-011` | Orden de mando comercial | Al crear o reubicar un rol `VENDEDOR` | El orden de mando de la fuerza comercial se expresa con `parent_role_id`: el rol superior es el rol padre. No existe un campo de rango aparte | Alta |
 | `RN-SP-004` | Permisos inmutables por API | Siempre | Los permisos no se crean, editan ni eliminan por la API: se pueblan y modifican únicamente por migración | Alta |
 | `RN-SP-005` | Revocación sin motivo | Al retirar un permiso de un rol | La fila de asociación se elimina físicamente y se audita en `audit_deletion_log` sin motivo declarado (Art. V.13, excepción de asociaciones) | Alta |
 | `RN-SP-006` | Membresía acotada por nivel | Al crear una membresía | Toda membresía está sujeta a una de mayor nivel; solo la membresía superior queda libre de ella | Alta |
@@ -210,14 +209,12 @@ Reglas que no son transversales de seguridad y por tanto sí llevan el prefijo d
 | Actor | Administrador |
 | Permiso requerido | `roles:create` |
 | Prioridad | Crítica |
-| Reglas aplicables | `RN-SEG-001`, `RN-SEG-003`, `RN-SEG-007`, `RN-SEG-010`, `RN-SP-002`, `RN-SP-003`, `RN-SP-011`, `RN-SP-012` |
+| Reglas aplicables | `RN-SEG-001`, `RN-SEG-003`, `RN-SEG-007`, `RN-SEG-010`, `RN-SP-002`, `RN-SP-003`, `RN-SP-011` |
 | Depende de | `RF-SP-010` |
 | Tripleta | `docs/specs/sp/001-registrar-rol/` |
 | Estado | Pendiente |
 
 El sistema debe permitir a un usuario autorizado registrar un rol con su código, nombre, descripción, clasificación, rol padre y conjunto inicial de permisos. Los permisos declarados quedan acotados por los del rol padre y por los del propio actor que lo crea.
-
-Si la clasificación es `VENDEDOR`, el alta exige además su **rango** dentro de la fuerza comercial, único entre los roles vendedores (`RN-SP-011`, `RN-SP-012`).
 
 #### `RF-SP-002` — Consultar roles
 
@@ -605,7 +602,6 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 | `name` | `varchar(100)` | No | No | No | — | — |
 | `description` | `text` | No | No | Sí | — | — |
 | `role_type` | `varchar(20)` | No | No | No | — | — |
-| `sales_rank` | `smallint` | No | No | Sí | — | — |
 | `parent_role_id` | `uuid` | No | Sí | Sí | — | `roles` |
 | `status` | `varchar(20)` | No | No | No | `ACTIVO` | — |
 | `is_system` | `boolean` | No | No | No | `false` | — |
@@ -625,23 +621,19 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 
 De él depende, entre otras cosas, qué roles pueden asociarse a una membresía —solo los `CONSUMIDOR`— y cuáles declaran rango comercial.
 
-`sales_rank` ordena los roles de la fuerza comercial: menor valor, mayor mando. Es **obligatorio y único** en los roles `VENDEDOR` y **nulo** en los demás (`RN-SP-011`, `RN-SP-012`).
+El orden de mando de la fuerza comercial se expresa con **`parent_role_id`**, el mismo campo que acota los permisos: el rol superior es el rol padre (`RN-SP-011`). No hay un campo de rango aparte.
 
-!!! important "Por qué el rango es un campo aparte y no `parent_role_id`"
+!!! important "Consecuencia de usar `parent_role_id` para las dos cosas"
 
-    `parent_role_id` acota **permisos** (`RN-SEG-003`). `sales_rank` ordena **el mando**. Hoy coinciden —el agente tiene menos permisos *y* está más abajo—, pero son cosas distintas.
+    Para los roles `VENDEDOR`, la cadena de mando y la contención de privilegios son **la misma relación**. Eso impone una condición permanente: **un rol comercial nunca puede tener un permiso que su superior no tenga**, porque `RN-SEG-003` lo rechazaría.
 
-    Si el mando se dedujera de `parent_role_id`, cambiar el alcance de permisos de un rol movería en silencio la cadena de mando, y al revés. El día que un rol comercial necesite un permiso que su superior no tenga, ambos usos quedarían enfrentados y no habría forma de expresarlo.
+    Es coherente con la estructura actual —el agente hace menos que el director, y el director menos que el manager— y mantiene un solo lugar donde mirar. Si alguna vez se necesitara que un rol comercial pudiera algo que su superior no puede, habría que separar ambos ejes.
 
-    Un entero da además **orden total**, que es exactamente lo que «quién está por encima de quién» necesita, y deja a `parent_role_id` haciendo una sola cosa.
+!!! note "El orden es entre roles, no entre personas"
 
-!!! note "El rango ordena roles, no personas"
-
-    `sales_rank` establece que un director está por encima de un agente. **No** dice qué agentes tiene un director concreto: esa es una relación entre personas y forma parte de la estructura comercial, hoy aparcada.
+    `parent_role_id` establece que un director está por encima de un agente. **No** dice qué agentes tiene un director concreto: esa es una relación entre personas y forma parte de la estructura comercial, hoy aparcada.
 
     Tampoco determina el alcance de datos, que sigue pendiente como **D-22**.
-
-    Queda además sin cubrir el **reordenamiento**: insertar un rango intermedio obligaría a desplazar los existentes, y ningún requerimiento lo contempla todavía.
 
 ### 10.3 Campos principales — `role_permissions`
 
@@ -709,8 +701,6 @@ Declaradas en la base de datos, no solo en Java (Art. V.6):
 | `fk_roles_parent` | `roles(parent_role_id)` → `roles(id)`, con restricción de eliminación — `RN-SEG-008` |
 | `ck_roles_status` | `roles(status)` en (`ACTIVO`, `INACTIVO`) — `RN-SEG-002` |
 | `ck_roles_type` | `roles(role_type)` en (`FUNCIONARIO`, `VENDEDOR`, `CONSUMIDOR`) — `RN-SP-003` |
-| `ck_roles_sales_rank` | `(role_type = 'VENDEDOR') = (sales_rank IS NOT NULL)` — `RN-SP-011` |
-| `uq_roles_sales_rank` | **Índice único parcial**: `roles(sales_rank) WHERE sales_rank IS NOT NULL` — `RN-SP-012` |
 | `fk_role_permissions_roles` | `role_permissions(role_id)` → `roles(id)` |
 | `fk_role_permissions_permissions` | `role_permissions(permission_id)` → `permissions(id)` |
 | `fk_memberships_parent` | `memberships(parent_membership_id)` → `memberships(id)` — `RN-SP-006` |
@@ -747,3 +737,4 @@ Definidos en [`architecture.md` §6.6](../architecture.md), que detalla el núcl
 | 0.4.0 | 20-08-2026 | Se complementa con la guía `guides/001-sp.md`: tres submódulos nuevos (membresías, monedas, países), siete requerimientos, diez reglas propias `RN-SP-` y las consecuencias de esquema derivadas (unicidad parcial por borrado lógico y clasificación del rol). | Responsable técnico |
 | 0.5.0 | 20-08-2026 | Se cierran los puntos abiertos: `SUPERADMIN` queda documentado como rol técnico y `ADMIN` como máximo rol de negocio, la convención `RN-SEG` frente a `RN-SP` queda resuelta, y la unicidad de hija de las membresías se garantiza en el esquema. | Responsable técnico |
 | 0.6.0 | 20-08-2026 | `role_type` pasa a tres valores con `VENDEDOR`, y los roles vendedores declaran `sales_rank` para ordenar el mando dentro de la fuerza comercial. Nuevas reglas `RN-SP-011` y `RN-SP-012`. | Responsable técnico |
+| 0.7.0 | 20-08-2026 | Se retira `sales_rank`: el orden de mando comercial se expresa con `parent_role_id`, el mismo campo que acota los permisos. `RN-SP-011` se reescribe y `RN-SP-012` queda retirada, con su número consumido. | Responsable técnico |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -4,7 +4,7 @@
 |---|---|
 | Módulo | `SP` — Sistema Principal |
 | Paquete | `modules/system` |
-| Versión | 0.3.0 |
+| Versión | 0.4.0 |
 | Estado | **Borrador** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -51,14 +51,17 @@ Según [`modules.md` §5.1](../modules.md).
 
 | Submódulo | Responsabilidad | Requerimientos |
 |---|---|---|
-| Permisos | Catálogo de permisos. Solo lectura por API; se pueblan por migración | `RF-SP-010` |
-| Roles | Alta, edición, estado, contención de privilegios y jerarquía | `RF-SP-001` a `RF-SP-009` |
+| Roles | Alta, consulta, edición, estado, jerarquía y eliminación | `RF-SP-001` a `RF-SP-004`, `RF-SP-007` a `RF-SP-009` |
+| Permisos | Catálogo de permisos. Solo lectura por API | `RF-SP-010`, `RF-SP-015` |
+| Roles y permisos | Asociación y revocación de permisos sobre un rol | `RF-SP-005`, `RF-SP-006` |
+| Membresías | Nivel de acceso del consumidor a servicios y contenidos | `RF-SP-016` a `RF-SP-018` |
+| Monedas | Catálogo de monedas. Solo lectura por API | `RF-SP-019` |
+| Países | Catálogo de países | `RF-SP-020`, `RF-SP-021` |
 | Auditoría | Consulta de los cuatro registros | `RF-SP-011` a `RF-SP-014` |
-| Parámetros | Configuración transversal del sistema | *(sin requerimientos: alcance por definir)* |
 
-!!! warning "Submódulo Parámetros sin definir"
+!!! note "Sobre el submódulo Parámetros"
 
-    `modules.md` §5.1 registra este submódulo con sus entidades «por definir». Mientras no se le asignen requerimientos, el módulo `SP` no puede darse por completo.
+    `modules.md` §5.1 registraba un submódulo «Parámetros» con alcance por definir. Los catálogos de **Monedas** y **Países** cubren lo que se esperaba de él, de modo que se retira como submódulo propio. Si aparece configuración transversal que no sea un catálogo, deberá registrarse de nuevo con su propio alcance.
 
 ## 3. Dependencias
 
@@ -144,6 +147,29 @@ Las reglas de autorización están definidas en [`security.md` §4.3](../securit
 
     Recomiendo la segunda: son reglas que cruzan módulos por naturaleza, y renombrarlas obligaría a partir tres de ellas.
 
+### 5.1 Reglas propias del módulo
+
+Reglas que no son transversales de seguridad y por tanto sí llevan el prefijo del módulo.
+
+| ID | Regla | Cuándo aplica | Qué debe ocurrir | Prioridad |
+|---|---|---|---|---|
+| `RN-SP-001` | Superadministrador siempre presente | Al eliminar o desactivar un usuario, o al retirarle el rol | Debe existir siempre al menos un usuario con rol `SUPERADMIN`; la operación que dejaría al sistema sin ninguno se rechaza | **Crítica** |
+| `RN-SP-002` | Rol padre obligatorio | Al crear o editar un rol | Todo rol declara un rol padre, salvo `SUPERADMIN`, que es el único sin él | Alta |
+| `RN-SP-003` | Clasificación del rol | Al crear un rol | Todo rol se clasifica como `FUNCIONARIO` (personal de la empresa) o `CONSUMIDOR` (cliente del sistema) | Alta |
+| `RN-SP-004` | Permisos inmutables por API | Siempre | Los permisos no se crean, editan ni eliminan por la API: se pueblan y modifican únicamente por migración | Alta |
+| `RN-SP-005` | Revocación sin motivo | Al retirar un permiso de un rol | La fila de asociación se elimina físicamente y se audita en `audit_deletion_log` sin motivo declarado (Art. V.13, excepción de asociaciones) | Alta |
+| `RN-SP-006` | Membresía acotada por nivel | Al crear una membresía | Toda membresía está sujeta a una de mayor nivel; solo la membresía superior queda libre de ella | Alta |
+| `RN-SP-007` | Inserción en la cadena de membresías | Al crear una membresía | Se indica cuál es su membresía hija y el sistema reordena la jerarquía en consecuencia | Alta |
+| `RN-SP-008` | Membresías inmutables | Al editar o eliminar una membresía | La operación se rechaza. Solo se admite el reordenamiento derivado de `RN-SP-007` | Media |
+| `RN-SP-009` | Países inmutables | Al editar o eliminar un país | La operación se rechaza | Media |
+| `RN-SP-010` | Monedas inmutables por API | Siempre | Las monedas no se crean, editan ni eliminan por la API | Media |
+
+!!! info "Sobre `RN-SP-005`"
+
+    Retirar un permiso de un rol **elimina físicamente** la fila de `role_permissions`, y por tanto se audita en `audit_deletion_log`. No se exige motivo: una asociación rol-permiso no es una entidad de negocio y su «por qué» ya está en el propio evento —qué permiso, de qué rol, quién y cuándo—. Un motivo de texto libre aquí se rellenaría con ruido.
+
+    Esto exigió enmendar el Art. V.13, que prohibía las eliminaciones sin motivo. La excepción quedó acotada a las asociaciones.
+
 ## 6. Requerimientos funcionales
 
 ### 6.1 Resumen
@@ -164,6 +190,13 @@ Las reglas de autorización están definidas en [`security.md` §4.3](../securit
 | `RF-SP-012` | Consultar auditoría de eliminación | Media | `audit:read-deletions` | Pendiente |
 | `RF-SP-013` | Consultar auditoría de error | Media | `audit:read-errors` | Pendiente |
 | `RF-SP-014` | Consultar auditoría de seguridad | Alta | `audit:read-security` | Pendiente |
+| `RF-SP-015` | Consultar detalle de un permiso | Media | `permissions:read` | Pendiente |
+| `RF-SP-016` | Registrar membresía | Alta | `memberships:create` | Pendiente |
+| `RF-SP-017` | Consultar membresías | Alta | `memberships:read` | Pendiente |
+| `RF-SP-018` | Consultar detalle de una membresía | Media | `memberships:read` | Pendiente |
+| `RF-SP-019` | Consultar monedas | Media | `currencies:read` | Pendiente |
+| `RF-SP-020` | Registrar país | Media | `countries:create` | Pendiente |
+| `RF-SP-021` | Consultar países | Media | `countries:read` | Pendiente |
 
 **Orden sugerido de implementación:** `RF-SP-010` → `RF-SP-001` → `RF-SP-002` → `RF-SP-005` → el resto. El catálogo de permisos es prerrequisito de todo lo demás, y sin roles no hay nada que auditar.
 
@@ -379,6 +412,111 @@ Consulta paginada de `audit_error_log`, con filtro por tipo de error, severidad,
 
 Consulta paginada de `audit_security_log`, con filtro por tipo de evento, severidad, resultado y actor. Su permiso se concede aparte de los demás de auditoría (`security.md` §8).
 
+#### `RF-SP-015` — Consultar detalle de un permiso
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Conocer el alcance exacto de un permiso antes de asignarlo a un rol |
+| Actor | Super Administrador, Administrador |
+| Permiso requerido | `permissions:read` |
+| Prioridad | Media |
+| Reglas aplicables | `RN-SP-004` |
+| Depende de | `RF-SP-010` |
+| Tripleta | `docs/specs/sp/015-consultar-detalle-permiso/` |
+| Estado | Pendiente |
+
+Devuelve un permiso con su recurso, acción, nombre y descripción legible.
+
+#### `RF-SP-016` — Registrar membresía
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Definir un nivel de acceso para los consumidores del sistema |
+| Actor | Super Administrador, Administrador |
+| Permiso requerido | `memberships:create` |
+| Prioridad | Alta |
+| Reglas aplicables | `RN-SP-006`, `RN-SP-007` |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/016-registrar-membresia/` |
+| Estado | Pendiente |
+
+Crea una membresía indicando cuál será su membresía hija; el sistema la inserta en la cadena y reordena la jerarquía. La membresía determina a qué servicios y contenidos accede un consumidor: un curso puede estar disponible solo desde cierto nivel.
+
+#### `RF-SP-017` — Consultar membresías
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Ver los niveles definidos y su orden en la jerarquía |
+| Actor | Super Administrador, Administrador |
+| Permiso requerido | `memberships:read` |
+| Prioridad | Alta |
+| Reglas aplicables | — |
+| Depende de | `RF-SP-016` |
+| Tripleta | `docs/specs/sp/017-consultar-membresias/` |
+| Estado | Pendiente |
+
+Listado paginado, presentado según el orden de la jerarquía y no por fecha de creación: el orden es la información relevante.
+
+#### `RF-SP-018` — Consultar detalle de una membresía
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Conocer el nivel de una membresía y su posición en la cadena |
+| Actor | Super Administrador, Administrador |
+| Permiso requerido | `memberships:read` |
+| Prioridad | Media |
+| Reglas aplicables | — |
+| Depende de | `RF-SP-016` |
+| Tripleta | `docs/specs/sp/018-consultar-detalle-membresia/` |
+| Estado | Pendiente |
+
+Devuelve la membresía con su membresía superior y su membresía hija.
+
+#### `RF-SP-019` — Consultar monedas
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Disponer del catálogo de monedas para las operaciones financieras |
+| Actor | Cualquier rol autenticado con el permiso |
+| Permiso requerido | `currencies:read` |
+| Prioridad | Media |
+| Reglas aplicables | `RN-SP-010` |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/019-consultar-monedas/` |
+| Estado | Pendiente |
+
+Listado de monedas. Hoy contiene únicamente `USD`; el catálogo existe para que incorporar otra moneda no exija cambiar el modelo de datos más adelante.
+
+#### `RF-SP-020` — Registrar país
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Incorporar un país al catálogo |
+| Actor | Super Administrador, Administrador |
+| Permiso requerido | `countries:create` |
+| Prioridad | Media |
+| Reglas aplicables | `RN-SP-009` |
+| Depende de | — |
+| Tripleta | `docs/specs/sp/020-registrar-pais/` |
+| Estado | Pendiente |
+
+Crea un país. Una vez creado no puede editarse ni eliminarse, de modo que la validación en el alta es la única oportunidad de evitar un dato incorrecto.
+
+#### `RF-SP-021` — Consultar países
+
+| Campo | Valor |
+|---|---|
+| Objetivo | Disponer del catálogo de países |
+| Actor | Cualquier rol autenticado con el permiso |
+| Permiso requerido | `countries:read` |
+| Prioridad | Media |
+| Reglas aplicables | — |
+| Depende de | `RF-SP-020` |
+| Tripleta | `docs/specs/sp/021-consultar-paises/` |
+| Estado | Pendiente |
+
+Listado de países.
+
 ## 7. Requerimientos no funcionales
 
 Definidos en [`security.md` §11](../security.md) y en la constitución. Los que este módulo debe satisfacer:
@@ -412,6 +550,13 @@ Ninguna con sistemas externos. Internamente, `USR` consume de este módulo el ca
 | `GET` | `/api/v1/audit/deletions` | `RF-SP-012` | `audit:read-deletions` |
 | `GET` | `/api/v1/audit/errors` | `RF-SP-013` | `audit:read-errors` |
 | `GET` | `/api/v1/audit/security` | `RF-SP-014` | `audit:read-security` |
+| `GET` | `/api/v1/permissions/{id}` | `RF-SP-015` | `permissions:read` |
+| `POST` | `/api/v1/memberships` | `RF-SP-016` | `memberships:create` |
+| `GET` | `/api/v1/memberships` | `RF-SP-017` | `memberships:read` |
+| `GET` | `/api/v1/memberships/{id}` | `RF-SP-018` | `memberships:read` |
+| `GET` | `/api/v1/currencies` | `RF-SP-019` | `currencies:read` |
+| `POST` | `/api/v1/countries` | `RF-SP-020` | `countries:create` |
+| `GET` | `/api/v1/countries` | `RF-SP-021` | `countries:read` |
 
 Rutas propuestas. El contrato exacto de cada una se fija en el `plan.md` de su tripleta.
 
@@ -422,6 +567,9 @@ Rutas propuestas. El contrato exacto de cada una se fija en el `plan.md` de su t
 | `permissions` | Catálogo de permisos `recurso:acción` | `SP` |
 | `roles` | Roles, su estado y su rol padre | `SP` |
 | `role_permissions` | Permisos declarados por cada rol | `SP` |
+| `memberships` | Niveles de acceso del consumidor | `SP` |
+| `currencies` | Catálogo de monedas | `SP` |
+| `countries` | Catálogo de países | `SP` |
 | `audit_change_log` | Auditoría de creación y edición | `SP` |
 | `audit_deletion_log` | Auditoría de eliminación | `SP` |
 | `audit_error_log` | Auditoría de fallos | `SP` |
@@ -454,6 +602,7 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 | `code` | `varchar(50)` | No | No | No | — | — |
 | `name` | `varchar(100)` | No | No | No | — | — |
 | `description` | `text` | No | No | Sí | — | — |
+| `role_type` | `varchar(20)` | No | No | No | — | — |
 | `parent_role_id` | `uuid` | No | Sí | Sí | — | `roles` |
 | `status` | `varchar(20)` | No | No | No | `ACTIVO` | — |
 | `is_system` | `boolean` | No | No | No | `false` | — |
@@ -461,7 +610,9 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 | `updated_at` | `timestamptz` | No | No | No | `now()` | — |
 | `deleted_at` | `timestamptz` | No | No | Sí | — | — |
 
-`parent_role_id` es nulo **únicamente** en el rol raíz (`RN-SEG-007`). No implica herencia: acota los privilegios del rol hijo (`security.md` §4.2).
+`parent_role_id` es nulo **únicamente** en el rol raíz (`RN-SEG-007`, `RN-SP-002`). No implica herencia: acota los privilegios del rol hijo (`security.md` §4.2).
+
+`role_type` distingue al personal de la empresa del cliente del sistema (`RN-SP-003`), con dominio cerrado `FUNCIONARIO` o `CONSUMIDOR`. De él depende, entre otras cosas, qué roles pueden asociarse a una membresía.
 
 ### 10.3 Campos principales — `role_permissions`
 
@@ -473,21 +624,82 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 
 Su clave primaria es **compuesta** (`role_id`, `permission_id`), y es la excepción declarada al Art. V.11: la unicidad del par es la restricción que importa, y una clave sustituta añadiría una columna sin significado.
 
-### 10.4 Restricciones exigidas en el esquema
+### 10.4 Campos principales — `memberships`
+
+| Campo | Tipo | PK | FK | Nullable | Default | Entidad relacional |
+|---|---|---|---|---|---|---|
+| `id` | `uuid` | Sí | No | No | — | — |
+| `code` | `varchar(50)` | No | No | No | — | — |
+| `name` | `varchar(100)` | No | No | No | — | — |
+| `description` | `text` | No | No | Sí | — | — |
+| `parent_membership_id` | `uuid` | No | Sí | Sí | — | `memberships` |
+| `level` | `smallint` | No | No | No | — | — |
+| `created_at` | `timestamptz` | No | No | No | `now()` | — |
+| `updated_at` | `timestamptz` | No | No | No | `now()` | — |
+
+`parent_membership_id` apunta a la membresía **de mayor nivel** y es nulo solo en la superior (`RN-SP-006`). `level` materializa el orden para poder consultarlo y ordenarlo sin recorrer la cadena; se recalcula al insertar una membresía nueva (`RN-SP-007`).
+
+!!! warning "La cadena de membresías no es un árbol"
+
+    Cada membresía tiene **una sola** hija: es una lista ordenada, no una jerarquía ramificada. Insertar una membresía en medio reencadena a su hija y desplaza los niveles siguientes.
+
+    Conviene decidir en la especificación si la unicidad de hija se garantiza en el esquema —restricción única sobre `parent_membership_id`— o solo en el dominio. Sin ella, nada impide que dos membresías declaren la misma superior y la cadena se bifurque.
+
+### 10.5 Campos principales — `currencies`
+
+| Campo | Tipo | PK | FK | Nullable | Default | Entidad relacional |
+|---|---|---|---|---|---|---|
+| `id` | `uuid` | Sí | No | No | — | — |
+| `code` | `char(3)` | No | No | No | — | — |
+| `name` | `varchar(100)` | No | No | No | — | — |
+| `symbol` | `varchar(10)` | No | No | Sí | — | — |
+| `created_at` | `timestamptz` | No | No | No | `now()` | — |
+
+`code` sigue ISO 4217 (`USD`). Se puebla por migración y no se modifica por API (`RN-SP-010`).
+
+### 10.6 Campos principales — `countries`
+
+| Campo | Tipo | PK | FK | Nullable | Default | Entidad relacional |
+|---|---|---|---|---|---|---|
+| `id` | `uuid` | Sí | No | No | — | — |
+| `code` | `char(2)` | No | No | No | — | — |
+| `name` | `varchar(100)` | No | No | No | — | — |
+| `created_at` | `timestamptz` | No | No | No | `now()` | — |
+
+`code` sigue ISO 3166-1 alfa-2 (`CO`, `US`). No se edita ni elimina (`RN-SP-009`).
+
+### 10.7 Restricciones exigidas en el esquema
 
 Declaradas en la base de datos, no solo en Java (Art. V.6):
 
 | Restricción | Sobre |
 |---|---|
 | `uq_permissions_code` | `permissions(code)` |
-| `uq_roles_code` | `roles(code)` — `RN-SEG-001` |
-| `uq_roles_name` | `roles(name)` — `RN-SEG-001` |
+| `uq_roles_code` | **Índice único parcial**: `roles(code) WHERE deleted_at IS NULL` — `RN-SEG-001` |
+| `uq_roles_name` | **Índice único parcial**: `roles(name) WHERE deleted_at IS NULL` — `RN-SEG-001` |
 | `fk_roles_parent` | `roles(parent_role_id)` → `roles(id)`, con restricción de eliminación — `RN-SEG-008` |
 | `ck_roles_status` | `roles(status)` en (`ACTIVO`, `INACTIVO`) — `RN-SEG-002` |
+| `ck_roles_type` | `roles(role_type)` en (`FUNCIONARIO`, `CONSUMIDOR`) — `RN-SP-003` |
 | `fk_role_permissions_roles` | `role_permissions(role_id)` → `roles(id)` |
 | `fk_role_permissions_permissions` | `role_permissions(permission_id)` → `permissions(id)` |
+| `fk_memberships_parent` | `memberships(parent_membership_id)` → `memberships(id)` — `RN-SP-006` |
+| `uq_memberships_code` | `memberships(code)` |
+| `uq_currencies_code` | `currencies(code)` |
+| `uq_countries_code` | `countries(code)` |
 
-`RN-SEG-006` (ausencia de ciclos) y `RN-SEG-003` (contención) **no** son expresables como restricción declarativa: se verifican en el dominio, y por eso exigen prueba unitaria propia.
+!!! important "La unicidad de rol es parcial, no total"
+
+    `RN-SEG-001` exige que el nombre y el código de un rol sean únicos **entre los no eliminados lógicamente**. Una restricción única corriente lo impediría: el nombre de un rol borrado quedaría bloqueado para siempre.
+
+    PostgreSQL lo resuelve con un índice único parcial:
+
+    ```sql
+    CREATE UNIQUE INDEX uq_roles_name ON roles (name) WHERE deleted_at IS NULL;
+    ```
+
+    Descubrirlo después de tener datos obliga a migrar la restricción con la tabla en uso.
+
+`RN-SEG-006` (ausencia de ciclos), `RN-SEG-003` (contención) y `RN-SP-001` (superadministrador siempre presente) **no** son expresables como restricción declarativa: se verifican en el dominio, y por eso exigen prueba unitaria propia.
 
 ### 10.5 Campos de los registros de auditoría
 
@@ -500,3 +712,4 @@ Definidos en [`architecture.md` §6.6](../architecture.md), que detalla el núcl
 | 0.1.0 | 20-08-2026 | Creación inicial. 14 requerimientos funcionales derivados de `security.md` y `modules.md`. | Responsable técnico |
 | 0.2.0 | 20-08-2026 | §10 incorpora los campos principales y las restricciones del esquema, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | §4 registra los siete roles reales de la Épica 2 (HU08–HU14) y propone su jerarquía de contención. Se advierte la distinción entre contención de privilegios y jerarquía comercial. | Responsable técnico |
+| 0.4.0 | 20-08-2026 | Se complementa con la guía `guides/001-sp.md`: tres submódulos nuevos (membresías, monedas, países), siete requerimientos, diez reglas propias `RN-SP-` y las consecuencias de esquema derivadas (unicidad parcial por borrado lógico y clasificación del rol). | Responsable técnico |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -66,19 +66,20 @@ Ninguna. `SP` es la raíz del grafo y debe seguir siéndolo: si llegara a depend
 
 ## 4. Actores
 
-Los actores de este módulo son los **roles del sistema**, definidos en la Épica 2 del documento de historias de usuario (HU08 a HU14).
+Los actores de este módulo son los **roles del sistema**.
 
-| Actor | Origen | Rol en este módulo | Permisos de `SP` |
-|---|---|---|---|
-| Administrador | HU08 | Define roles, su alcance de permisos y la configuración | `roles:*`, `permissions:read`, los cuatro de auditoría |
-| Contabilidad | HU09 | Consume roles; no los administra | `audit:read-changes`, `audit:read-deletions` |
-| Manager | HU10 | Consume roles; no los administra | — |
-| Director | HU11 | Consume roles; no los administra | — |
-| Agente o vendedor | HU12 | Consume roles; no los administra | — |
-| Estudiante | HU13 | Consume roles; no los administra | — |
-| Líder académico | HU14 | Consume roles; no los administra | — |
+| Actor | Rol en este módulo | Permisos de `SP` |
+|---|---|---|
+| Super Administrador | Tiene acceso completo al sistema | Posee todos los permisos |
+| Administrador | Define roles, su alcance de permisos y la configuración | `roles:*`, `permissions:read`, los cuatro de auditoría |
+| Contabilidad | Consume roles; no los administra | `audit:read-changes`, `audit:read-deletions` |
+| Manager | Consume roles; no los administra | — |
+| Director | Consume roles; no los administra | — |
+| Agente o vendedor | Consume roles; no los administra | — |
+| Estudiante | Consume roles; no los administra | — |
+| Líder académico | Consume roles; no los administra | — |
 
-Solo el **Administrador** opera sobre `SP`. Los demás roles aparecen aquí porque son los sujetos que `SP` define, no porque ejecuten sus requerimientos.
+Solo el **Super Administrador** y **Administrador** operan sobre `SP`. Los demás roles aparecen aquí porque son los sujetos que `SP` define, no porque ejecuten sus requerimientos.
 
 Los permisos de auditoría se conceden por separado: los cuatro registros no tienen la misma sensibilidad y no se leen en bloque ([`security.md` §4.4](../security.md)).
 
@@ -86,16 +87,16 @@ Los permisos de auditoría se conceden por separado: los cuatro registros no tie
 
 Propuesta de códigos y de jerarquía de **contención de privilegios** (`RN-SEG-003`). Cierra parcialmente la decisión D-17.
 
-| Código | Nombre | HU | Rol padre | `is_system` |
-|---|---|---|---|---|
-| `SUPERADMIN` | Superadministrador | — | — | Sí |
-| `ADMIN` | Administrador | HU08 | `SUPERADMIN` | Sí |
-| `CONTABILIDAD` | Contabilidad | HU09 | `ADMIN` | Sí |
-| `LIDER_ACADEMICO` | Líder académico | HU14 | `ADMIN` | Sí |
-| `MANAGER` | Manager | HU10 | `ADMIN` | Sí |
-| `DIRECTOR` | Director | HU11 | `MANAGER` | Sí |
-| `AGENTE` | Agente o vendedor | HU12 | `DIRECTOR` | Sí |
-| `ESTUDIANTE` | Estudiante | HU13 | `ADMIN` | Sí |
+| Código | Nombre | Rol padre | `is_system` |
+|---|---|---|---|
+| `SUPERADMIN` | Superadministrador | — | Sí |
+| `ADMIN` | Administrador | `SUPERADMIN` | Sí |
+| `CONTABILIDAD` | Contabilidad | `ADMIN` | Sí |
+| `LIDER_ACADEMICO` | Líder académico | `ADMIN` | Sí |
+| `MANAGER` | Manager | `ADMIN` | Sí |
+| `DIRECTOR` | Director | `MANAGER` | Sí |
+| `AGENTE` | Agente o vendedor | `DIRECTOR` | Sí |
+| `ESTUDIANTE` | Estudiante | `ADMIN` | Sí |
 
 !!! danger "Dos jerarquías distintas que NO deben confundirse"
 

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -4,7 +4,7 @@
 |---|---|
 | Módulo | `SP` — Sistema Principal |
 | Paquete | `modules/system` |
-| Versión | 0.4.0 |
+| Versión | 0.5.0 |
 | Estado | **Borrador** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -99,23 +99,26 @@ Propuesta de códigos y de jerarquía de **contención de privilegios** (`RN-SEG
 | `MANAGER` | Manager | `ADMIN` | Sí |
 | `DIRECTOR` | Director | `MANAGER` | Sí |
 | `AGENTE` | Agente o vendedor | `DIRECTOR` | Sí |
-| `ESTUDIANTE` | Estudiante | `ADMIN` | Sí |
+| `ESTUDIANTE` | Estudiante | `ADMIN` | No |
+| `Cliente` | Cliente | `ADMIN` | No |
 
-!!! danger "Dos jerarquías distintas que NO deben confundirse"
+!!! important "Qué acota `parent_role_id`, y qué no"
 
-    La columna «Rol padre» de esta tabla es **contención de privilegios**: acota qué permisos puede declarar cada rol (`RN-SEG-003`). Es una relación **rol → rol**.
+    La columna «Rol padre» es **contención de privilegios**: acota qué permisos puede declarar cada rol (`RN-SEG-003`). Es una relación **rol → rol** y no dice nada sobre los datos.
 
-    La cadena comercial **manager → director → agente** de HU10, HU11 y HU12 es otra cosa: una relación **persona → persona** que determina **de quién** puede ver los datos cada uno.
+    La estructura comercial —manager, director y agente— es otra cosa: una relación **persona → persona** que determina **de quién** puede ver los datos cada uno. Los tres roles necesitan el mismo permiso sobre comisiones; lo que cambia es el conjunto de registros.
 
-    Los tres roles piden el **mismo permiso** (`commissions:read`); lo que cambia es el conjunto de datos. Modelar la red comercial en `roles.parent_role_id` sería un error: esa columna no acota datos, y además relaciona roles, no usuarios. La red comercial necesita su propia estructura, en `USR` o en un módulo de red comercial.
+    Modelar esa estructura en `roles.parent_role_id` sería un error: esa columna no acota datos y relaciona roles, no usuarios. Cuando el alcance comercial se retome, necesitará su propia estructura y su propio modelo de alcance (D-22).
 
     Que ambas jerarquías coincidan en forma es una casualidad de este dominio, no una equivalencia.
 
-!!! warning "Requiere confirmación"
+!!! note "Por qué `SUPERADMIN` está por encima de `ADMIN`"
 
-    - **¿`ADMIN` contiene realmente a `CONTABILIDAD`?** La contención exige que `ADMIN` posea **todos** los permisos financieros. HU08 menciona pagos y comisiones, pero no retiros, balances ni egresos. Si el negocio quiere que Contabilidad pueda algo que Administración no, `CONTABILIDAD` debe colgar de `SUPERADMIN`, no de `ADMIN`.
-    - **¿`ADMIN` es el rol raíz, o existe `SUPERADMIN` por encima?** HU08 dice «acceso completo», y `RN-SEG-007` exige exactamente un rol raíz. Si `ADMIN` fuera la raíz, no habría quién lo cree ni quién lo acote.
-    - **HU14 tiene el actor cambiado:** está redactada desde el administrador que asigna el rol, no desde el líder académico. Esa funcionalidad pertenece a `USR`; falta la historia del líder académico desde su propia perspectiva.
+    `SUPERADMIN` es el **rol técnico del responsable del software**, no un rol de negocio. Existe para las funcionalidades reservadas a quien desarrolla y mantiene la plataforma, que se irán definiendo, y para satisfacer `RN-SEG-007`: alguien tiene que poder crear y acotar al administrador.
+
+    `ADMIN` es el **máximo rol de negocio**: tiene acceso completo a la operación, y por eso todos los roles funcionales cuelgan de él. La contención (`RN-SEG-003`) obliga entonces a que `ADMIN` posea todo permiso que cualquier rol de negocio declare, incluidos los financieros de `CONTABILIDAD`.
+
+    **Consecuencia a tener presente:** con este diseño no hay separación entre quien configura el sistema y quien controla el dinero. Si en algún momento se quiere que Contabilidad pueda aprobar algo que Administración no, habrá que colgarla de `SUPERADMIN`.
 
 ## 5. Reglas de negocio
 
@@ -136,16 +139,11 @@ Las reglas de autorización están definidas en [`security.md` §4.3](../securit
 | `RN-SEG-012` | Los roles de sistema no se modifican ni eliminan por la API | `RF-SP-004` a `RF-SP-009` |
 | `RN-SEG-013` | Cambiar el rol padre revalida `RN-SEG-003` contra el nuevo padre | `RF-SP-008` |
 
-!!! danger "Punto abierto: prefijo de las reglas"
+!!! note "Por qué estas reglas llevan `SEG` y no `SP`"
 
-    La nomenclatura de [`requirements.md` §3.1](../requirements.md) define las reglas de negocio como `RN-[MÓDULO]-NNN`, pero estas usan `RN-SEG-…`, y `SEG` **no es un código de módulo**: es una categoría de requerimiento no funcional.
+    `RN-SEG-…` es el espacio de las **reglas transversales de seguridad**: gobiernan la autorización en todo el sistema y varias de ellas —`RN-SEG-009`, `010` y `011`— alcanzan también a `USR`. Renombrarlas al código de un módulo obligaría a partirlas.
 
-    Hay que decidir antes de que las reglas se referencien desde el código:
-
-    - **Renombrar** a `RN-SP-…` las que pertenecen a este módulo. Cumple la nomenclatura, pero `RN-SEG-009`, `010` y `011` abarcan también a `USR`, así que ninguna asignación es limpia.
-    - **Declarar `SEG` como espacio de reglas transversales de seguridad**, documentando la excepción en `requirements.md` §3.1.
-
-    Recomiendo la segunda: son reglas que cruzan módulos por naturaleza, y renombrarlas obligaría a partir tres de ellas.
+    Las reglas propias de este módulo sí llevan su prefijo y están en §5.1 como `RN-SP-…`. La convención completa está en [`requirements.md` §3.1](../requirements.md).
 
 ### 5.1 Reglas propias del módulo
 
@@ -639,11 +637,11 @@ Su clave primaria es **compuesta** (`role_id`, `permission_id`), y es la excepci
 
 `parent_membership_id` apunta a la membresía **de mayor nivel** y es nulo solo en la superior (`RN-SP-006`). `level` materializa el orden para poder consultarlo y ordenarlo sin recorrer la cadena; se recalcula al insertar una membresía nueva (`RN-SP-007`).
 
-!!! warning "La cadena de membresías no es un árbol"
+!!! important "La cadena de membresías no es un árbol"
 
     Cada membresía tiene **una sola** hija: es una lista ordenada, no una jerarquía ramificada. Insertar una membresía en medio reencadena a su hija y desplaza los niveles siguientes.
 
-    Conviene decidir en la especificación si la unicidad de hija se garantiza en el esquema —restricción única sobre `parent_membership_id`— o solo en el dominio. Sin ella, nada impide que dos membresías declaren la misma superior y la cadena se bifurque.
+    Que dos membresías no puedan declarar la misma superior se garantiza **en el esquema**, con una restricción única sobre `parent_membership_id` (`uq_memberships_parent`), no solo en el dominio: el Art. V.6 exige declarar la integridad en la base de datos. Sin ella, la cadena podría bifurcarse y el orden dejaría de estar definido.
 
 ### 10.5 Campos principales — `currencies`
 
@@ -683,6 +681,7 @@ Declaradas en la base de datos, no solo en Java (Art. V.6):
 | `fk_role_permissions_roles` | `role_permissions(role_id)` → `roles(id)` |
 | `fk_role_permissions_permissions` | `role_permissions(permission_id)` → `permissions(id)` |
 | `fk_memberships_parent` | `memberships(parent_membership_id)` → `memberships(id)` — `RN-SP-006` |
+| `uq_memberships_parent` | `memberships(parent_membership_id)` — garantiza una sola hija por membresía |
 | `uq_memberships_code` | `memberships(code)` |
 | `uq_currencies_code` | `currencies(code)` |
 | `uq_countries_code` | `countries(code)` |
@@ -713,3 +712,4 @@ Definidos en [`architecture.md` §6.6](../architecture.md), que detalla el núcl
 | 0.2.0 | 20-08-2026 | §10 incorpora los campos principales y las restricciones del esquema, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | §4 registra los siete roles reales de la Épica 2 (HU08–HU14) y propone su jerarquía de contención. Se advierte la distinción entre contención de privilegios y jerarquía comercial. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | Se complementa con la guía `guides/001-sp.md`: tres submódulos nuevos (membresías, monedas, países), siete requerimientos, diez reglas propias `RN-SP-` y las consecuencias de esquema derivadas (unicidad parcial por borrado lógico y clasificación del rol). | Responsable técnico |
+| 0.5.0 | 20-08-2026 | Se cierran los puntos abiertos: `SUPERADMIN` queda documentado como rol técnico y `ADMIN` como máximo rol de negocio, la convención `RN-SEG` frente a `RN-SP` queda resuelta, y la unicidad de hija de las membresías se garantiza en el esquema. | Responsable técnico |

--- a/docs/requirements/sp.md
+++ b/docs/requirements/sp.md
@@ -4,7 +4,7 @@
 |---|---|
 | Módulo | `SP` — Sistema Principal |
 | Paquete | `modules/system` |
-| Versión | 0.1.0 |
+| Versión | 0.2.0 |
 | Estado | **Borrador** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 20-08-2026 |
@@ -77,7 +77,7 @@ Los permisos de auditoría se conceden por separado: los cuatro registros no tie
 
 ## 5. Reglas de negocio
 
-Las reglas de autorización están definidas en [`security.md` §4.3](../security.md) y **no se redefinen aquí**.
+Las reglas de autorización están definidas en [`security.md` §4.3](../security.md), donde cada una declara cuándo aplica, qué debe ocurrir y su prioridad. **No se redefinen aquí**: esta tabla solo indica a qué requerimiento afecta cada una.
 
 | ID | Regla | Aplica a |
 |---|---|---|
@@ -392,8 +392,71 @@ Estructura lógica en [`security.md` §9](../security.md) y [`architecture.md` �
 
 `SP` es dueño de las cuatro tablas de auditoría, pero **no es quien las escribe**: cada módulo emite sus propios eventos al ejecutar sus operaciones. `SP` publica la interfaz de escritura y es el único que las consulta por API.
 
+### 10.1 Campos principales — `permissions`
+
+| Campo | Tipo | PK | FK | Nullable | Default | Entidad relacional |
+|---|---|---|---|---|---|---|
+| `id` | `uuid` | Sí | No | No | — | — |
+| `code` | `varchar(100)` | No | No | No | — | — |
+| `resource` | `varchar(50)` | No | No | No | — | — |
+| `action` | `varchar(50)` | No | No | No | — | — |
+| `name` | `varchar(100)` | No | No | No | — | — |
+| `description` | `text` | No | No | Sí | — | — |
+| `created_at` | `timestamptz` | No | No | No | `now()` | — |
+| `updated_at` | `timestamptz` | No | No | No | `now()` | — |
+
+`code` es la concatenación `resource:action` y es único (`uq_permissions_code`). Se mantiene como columna propia para poder consultarlo y referenciarlo directamente.
+
+### 10.2 Campos principales — `roles`
+
+| Campo | Tipo | PK | FK | Nullable | Default | Entidad relacional |
+|---|---|---|---|---|---|---|
+| `id` | `uuid` | Sí | No | No | — | — |
+| `code` | `varchar(50)` | No | No | No | — | — |
+| `name` | `varchar(100)` | No | No | No | — | — |
+| `description` | `text` | No | No | Sí | — | — |
+| `parent_role_id` | `uuid` | No | Sí | Sí | — | `roles` |
+| `status` | `varchar(20)` | No | No | No | `ACTIVO` | — |
+| `is_system` | `boolean` | No | No | No | `false` | — |
+| `created_at` | `timestamptz` | No | No | No | `now()` | — |
+| `updated_at` | `timestamptz` | No | No | No | `now()` | — |
+| `deleted_at` | `timestamptz` | No | No | Sí | — | — |
+
+`parent_role_id` es nulo **únicamente** en el rol raíz (`RN-SEG-007`). No implica herencia: acota los privilegios del rol hijo (`security.md` §4.2).
+
+### 10.3 Campos principales — `role_permissions`
+
+| Campo | Tipo | PK | FK | Nullable | Default | Entidad relacional |
+|---|---|---|---|---|---|---|
+| `role_id` | `uuid` | Sí | Sí | No | — | `roles` |
+| `permission_id` | `uuid` | Sí | Sí | No | — | `permissions` |
+| `created_at` | `timestamptz` | No | No | No | `now()` | — |
+
+Su clave primaria es **compuesta** (`role_id`, `permission_id`), y es la excepción declarada al Art. V.11: la unicidad del par es la restricción que importa, y una clave sustituta añadiría una columna sin significado.
+
+### 10.4 Restricciones exigidas en el esquema
+
+Declaradas en la base de datos, no solo en Java (Art. V.6):
+
+| Restricción | Sobre |
+|---|---|
+| `uq_permissions_code` | `permissions(code)` |
+| `uq_roles_code` | `roles(code)` — `RN-SEG-001` |
+| `uq_roles_name` | `roles(name)` — `RN-SEG-001` |
+| `fk_roles_parent` | `roles(parent_role_id)` → `roles(id)`, con restricción de eliminación — `RN-SEG-008` |
+| `ck_roles_status` | `roles(status)` en (`ACTIVO`, `INACTIVO`) — `RN-SEG-002` |
+| `fk_role_permissions_roles` | `role_permissions(role_id)` → `roles(id)` |
+| `fk_role_permissions_permissions` | `role_permissions(permission_id)` → `permissions(id)` |
+
+`RN-SEG-006` (ausencia de ciclos) y `RN-SEG-003` (contención) **no** son expresables como restricción declarativa: se verifican en el dominio, y por eso exigen prueba unitaria propia.
+
+### 10.5 Campos de los registros de auditoría
+
+Definidos en [`architecture.md` §6.6](../architecture.md), que detalla el núcleo común de las cuatro tablas y las columnas propias de cada una. No se repiten aquí.
+
 ## 11. Control de cambios
 
 | Versión | Fecha | Cambio | Responsable |
 |---|---|---|---|
 | 0.1.0 | 20-08-2026 | Creación inicial. 14 requerimientos funcionales derivados de `security.md` y `modules.md`. | Responsable técnico |
+| 0.2.0 | 20-08-2026 | §10 incorpora los campos principales y las restricciones del esquema, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,13 +5,13 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `security.md` |
-| Versión | 0.2.0 |
+| Versión | 0.3.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
 | Última actualización | 19-08-2026 |
-| Documento superior | `constitution.md` v0.3.0 |
-| Documento relacionado | `architecture.md` v0.3.0 |
+| Documento superior | `constitution.md` v0.5.0 |
+| Documento relacionado | `architecture.md` v0.4.0 |
 
 ---
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `security.md` |
-| Versión | 0.6.0 |
+| Versión | 0.7.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
@@ -248,13 +248,13 @@ Si llega un refresh token **ya revocado**, el sistema asume robo de credenciales
 - Un endpoint **sin declaración explícita** de permiso queda **inaccesible**, no público. La configuración por defecto deniega, y la excepción (endpoints públicos como login o salud) se declara en una lista explícita y corta, revisable de un vistazo.
 - La verificación de propiedad del dato (que un usuario solo acceda a sus propios registros, cuando aplique) es responsabilidad de la capa `application` y **DEBE** especificarse por requerimiento. Un permiso concede la capacidad de ejecutar una acción, no el derecho sobre un registro concreto.
 
-!!! danger "El alcance de datos no está diseñado"
+!!! note "El alcance de datos está pendiente de diseño (D-22)"
 
-    Lo anterior basta cuando el alcance es la excepción. Deja de bastar en este producto: de los siete roles de la Épica 2, cinco se definen precisamente por **de quién** ven los datos, no por qué pueden hacer. Manager, director y agente piden el mismo permiso sobre conjuntos distintos.
+    Lo anterior basta mientras el alcance sea la excepción, que es la situación actual: los roles, los permisos y los catálogos de `SP` son globales y ningún requerimiento vigente necesita acotar por persona.
 
-    El alcance de datos es un **eje ortogonal al permiso** y necesita diseño propio: qué lo determina, cómo se declara por requerimiento y cómo se verifica de forma automatizada. Registrado como **D-22**.
+    Deja de bastar en cuanto se retome la estructura comercial: manager, director y agente necesitan el **mismo permiso** sobre conjuntos de datos distintos. El alcance es un **eje ortogonal al permiso** y necesita diseño propio —qué lo determina, cómo se declara por requerimiento y cómo se verifica de forma automatizada—, registrado como **D-22**.
 
-    Hasta resolverlo, ninguna consulta con alcance por persona puede especificarse de forma completa.
+    Ningún requerimiento con alcance por persona debe especificarse antes de resolver D-22.
 - Ante falta de permiso se responde `403`; ante ausencia o invalidez del token, `401` (`architecture.md` §7.2).
 - **NO DEBE** usarse `404` para ocultar la existencia de un recurso salvo que la especificación lo exija de forma expresa y justificada.
 
@@ -445,3 +445,4 @@ RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrado
 | 0.4.0 | 20-08-2026 | Las reglas de §4.3 declaran cuándo aplican, qué debe ocurrir y su prioridad, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |
 | 0.5.0 | 20-08-2026 | Se registra D-22: el alcance de datos es un eje ortogonal al permiso y carece de diseño. Lo evidencia la Épica 2, donde cinco de siete roles se definen por el alcance y no por el permiso. | Responsable técnico |
 | 0.6.0 | 20-08-2026 | RN-SEG-001 acota la unicidad de rol a los no eliminados lógicamente, lo que la convierte en un índice único parcial. | Responsable técnico |
+| 0.7.0 | 20-08-2026 | D-22 pasa de aviso de peligro a pendiente registrado: ningún requerimiento vigente necesita alcance por persona. | Responsable técnico |

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `security.md` |
-| Versión | 0.4.0 |
+| Versión | 0.5.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
@@ -247,6 +247,14 @@ Si llega un refresh token **ya revocado**, el sistema asume robo de credenciales
 - La autorización se declara en la capa `api` (`architecture.md` §5.1), mediante anotaciones sobre cada endpoint.
 - Un endpoint **sin declaración explícita** de permiso queda **inaccesible**, no público. La configuración por defecto deniega, y la excepción (endpoints públicos como login o salud) se declara en una lista explícita y corta, revisable de un vistazo.
 - La verificación de propiedad del dato (que un usuario solo acceda a sus propios registros, cuando aplique) es responsabilidad de la capa `application` y **DEBE** especificarse por requerimiento. Un permiso concede la capacidad de ejecutar una acción, no el derecho sobre un registro concreto.
+
+!!! danger "El alcance de datos no está diseñado"
+
+    Lo anterior basta cuando el alcance es la excepción. Deja de bastar en este producto: de los siete roles de la Épica 2, cinco se definen precisamente por **de quién** ven los datos, no por qué pueden hacer. Manager, director y agente piden el mismo permiso sobre conjuntos distintos.
+
+    El alcance de datos es un **eje ortogonal al permiso** y necesita diseño propio: qué lo determina, cómo se declara por requerimiento y cómo se verifica de forma automatizada. Registrado como **D-22**.
+
+    Hasta resolverlo, ninguna consulta con alcance por persona puede especificarse de forma completa.
 - Ante falta de permiso se responde `403`; ante ausencia o invalidez del token, `401` (`architecture.md` §7.2).
 - **NO DEBE** usarse `404` para ocultar la existencia de un recurso salvo que la especificación lo exija de forma expresa y justificada.
 
@@ -421,6 +429,7 @@ RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrado
 | D-17 | Catálogo inicial completo de permisos y roles de sistema | Primera migración de seguridad |
 | D-18 | Política de restablecimiento de contraseña (canal, vigencia del enlace) | Módulo de usuarios |
 | D-19 | Identidad para procesos automáticos e integraciones | Cuando exista la primera integración |
+| **D-22** | **Modelo de alcance de datos**: cómo se determina *de quién* puede ver los datos un usuario, con independencia de qué permisos tenga | Red comercial, comisiones y finanzas; toda consulta con alcance por persona |
 | D-20 | Si el motivo de eliminación debe tipificarse (catálogo de códigos) además del texto libre del actor | Especificación de los endpoints `DELETE` de cada módulo |
 | D-21 | Lista de proxies confiables por entorno, de la que depende la validez de la IP registrada (Art. V.15) | Despliegue en `testing` y `production` |
 
@@ -434,3 +443,4 @@ RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrado
 | 0.2.0 | 19-08-2026 | `user_roles` deja de registrar `assigned_by`: el actor de la asignación reside en la auditoría. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | §8 pasa a definir `audit_security_log` como uno de los cuatro registros del Art. V.8: columnas propias, `target_user_id`, IP de origen y transacción independiente. §4.4 sustituye `audit:read` por cuatro permisos de lectura por tipo. Nuevo RNF-SEG-007 y pendientes D-20 y D-21. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | Las reglas de §4.3 declaran cuándo aplican, qué debe ocurrir y su prioridad, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |
+| 0.5.0 | 20-08-2026 | Se registra D-22: el alcance de datos es un eje ortogonal al permiso y carece de diseño. Lo evidencia la Épica 2, donde cinco de siete roles se definen por el alcance y no por el permiso. | Responsable técnico |

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `security.md` |
-| Versión | 0.3.0 |
+| Versión | 0.4.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
@@ -112,21 +112,23 @@ Lo que el padre impone es un **techo**:
 
 ### 4.3 Reglas de negocio
 
-| ID | Regla |
-|---|---|
-| **RN-SEG-001** | El código y el nombre de un rol son únicos en el sistema. |
-| **RN-SEG-002** | Un rol tiene uno de los estados definidos: `ACTIVO` o `INACTIVO`. Un rol `INACTIVO` no concede permisos, aunque siga asignado. |
-| **RN-SEG-003** | Los permisos de un rol deben ser un subconjunto de los permisos de su rol padre. La operación que viole esta condición se rechaza. |
-| **RN-SEG-004** | La validación de RN-SEG-003 se realiza contra el rol padre inmediato. No se recorre la cadena de ancestros. |
-| **RN-SEG-005** | Al revocar un permiso a un rol, si algún rol descendiente directo lo declara, la operación **se rechaza** e informa qué roles lo impiden. El sistema no revoca permisos en cascada de forma implícita. |
-| **RN-SEG-006** | La cadena de roles padre no puede formar ciclos. Un rol no puede ser ancestro de sí mismo. |
-| **RN-SEG-007** | Existe exactamente un rol raíz sin padre (`SUPERADMIN`), acotado por el catálogo completo de permisos. |
-| **RN-SEG-008** | Un rol no puede eliminarse si tiene roles hijos o usuarios asignados. Debe desactivarse o reasignarse previamente. |
-| **RN-SEG-009** | Los permisos efectivos de un usuario son la **unión** de los permisos de sus roles `ACTIVO`. |
-| **RN-SEG-010** | Un actor no puede asignar a otro usuario un rol cuyos permisos no estén contenidos en sus propios permisos efectivos. |
-| **RN-SEG-011** | Un usuario no puede modificar sus propios roles ni los permisos de los roles que tiene asignados. |
-| **RN-SEG-012** | Los roles marcados como de sistema no pueden modificarse ni eliminarse por la API. |
-| **RN-SEG-013** | Cambiar el rol padre de un rol exige revalidar RN-SEG-003 contra el nuevo padre. Si no se cumple, la operación se rechaza. |
+Cada regla declara cuándo aplica, qué debe ocurrir y su prioridad, conforme a la plantilla de requerimientos por módulo.
+
+| ID | Regla | Cuándo aplica | Qué debe ocurrir | Prioridad |
+|---|---|---|---|---|
+| **RN-SEG-001** | Unicidad de rol | Al crear o editar un rol | El código y el nombre son únicos en el sistema; el duplicado se rechaza | Alta |
+| **RN-SEG-002** | Estado del rol | Siempre que se resuelvan permisos | Un rol es `ACTIVO` o `INACTIVO`. Un rol `INACTIVO` no concede permisos, aunque siga asignado | Alta |
+| **RN-SEG-003** | Contención de privilegios | Al declarar o modificar los permisos de un rol | Sus permisos deben ser subconjunto de los de su rol padre; en caso contrario la operación se rechaza | **Crítica** |
+| **RN-SEG-004** | Validación de un solo nivel | Al verificar RN-SEG-003 | Se valida contra el padre inmediato, sin recorrer la cadena de ancestros: la contención es transitiva | Alta |
+| **RN-SEG-005** | Revocación sin cascada | Al retirar un permiso a un rol | Si un rol descendiente directo lo declara, la operación se rechaza e informa qué roles lo impiden. No se revoca en cascada de forma implícita | Alta |
+| **RN-SEG-006** | Ausencia de ciclos | Al asignar o cambiar el rol padre | La cadena de roles padre no puede formar ciclos; un rol no puede ser ancestro de sí mismo | **Crítica** |
+| **RN-SEG-007** | Rol raíz único | Al crear un rol sin padre | Existe exactamente un rol raíz (`SUPERADMIN`), acotado por el catálogo completo de permisos | Alta |
+| **RN-SEG-008** | Eliminación restringida | Al eliminar un rol | Se rechaza si tiene roles hijos o usuarios asignados; debe desactivarse o reasignarse antes | Alta |
+| **RN-SEG-009** | Permisos efectivos por unión | Al resolver qué puede hacer un usuario | Sus permisos son la unión de los de sus roles `ACTIVO` | **Crítica** |
+| **RN-SEG-010** | Nadie otorga lo que no tiene | Al asignar un rol a un usuario | Se rechaza si los permisos del rol no están contenidos en los permisos efectivos de quien asigna | **Crítica** |
+| **RN-SEG-011** | Sin autoconcesión | Al modificar roles o permisos | Un usuario no puede modificar sus propios roles, ni los permisos de los roles que tiene asignados | **Crítica** |
+| **RN-SEG-012** | Roles de sistema inmutables | Al modificar o eliminar un rol marcado como de sistema | La operación se rechaza por la API, sin excepción | Alta |
+| **RN-SEG-013** | Revalidación al reubicar | Al cambiar el rol padre de un rol | Se revalida RN-SEG-003 contra el nuevo padre; si no se cumple, la operación se rechaza | Alta |
 
 **Advertencia sobre RN-SEG-009 y RN-SEG-010.** La contención opera **entre roles**, no sobre el conjunto efectivo del usuario. Dos roles individualmente acotados pueden, en unión, otorgar más de lo que cualquiera de ellos concede por separado. Por eso RN-SEG-010 existe: acota la **asignación** al privilegio efectivo de quien asigna. Sin esa regla, el modelo de contención sería evadible asignando varios roles.
 
@@ -431,3 +433,4 @@ RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrado
 | 0.1.0 | 19-08-2026 | Creación inicial. Cierra D-08 y define el modelo de contención de privilegios. | Responsable técnico |
 | 0.2.0 | 19-08-2026 | `user_roles` deja de registrar `assigned_by`: el actor de la asignación reside en la auditoría. | Responsable técnico |
 | 0.3.0 | 20-08-2026 | §8 pasa a definir `audit_security_log` como uno de los cuatro registros del Art. V.8: columnas propias, `target_user_id`, IP de origen y transacción independiente. §4.4 sustituye `audit:read` por cuatro permisos de lectura por tipo. Nuevo RNF-SEG-007 y pendientes D-20 y D-21. | Responsable técnico |
+| 0.4.0 | 20-08-2026 | Las reglas de §4.3 declaran cuándo aplican, qué debe ocurrir y su prioridad, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |

--- a/docs/security.md
+++ b/docs/security.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `security.md` |
-| Versión | 0.5.0 |
+| Versión | 0.6.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
@@ -116,7 +116,7 @@ Cada regla declara cuándo aplica, qué debe ocurrir y su prioridad, conforme a 
 
 | ID | Regla | Cuándo aplica | Qué debe ocurrir | Prioridad |
 |---|---|---|---|---|
-| **RN-SEG-001** | Unicidad de rol | Al crear o editar un rol | El código y el nombre son únicos en el sistema; el duplicado se rechaza | Alta |
+| **RN-SEG-001** | Unicidad de rol | Al crear o editar un rol | El código y el nombre son únicos **entre los roles no eliminados lógicamente**; el duplicado se rechaza. El identificador de un rol eliminado queda liberado para reutilizarse | Alta |
 | **RN-SEG-002** | Estado del rol | Siempre que se resuelvan permisos | Un rol es `ACTIVO` o `INACTIVO`. Un rol `INACTIVO` no concede permisos, aunque siga asignado | Alta |
 | **RN-SEG-003** | Contención de privilegios | Al declarar o modificar los permisos de un rol | Sus permisos deben ser subconjunto de los de su rol padre; en caso contrario la operación se rechaza | **Crítica** |
 | **RN-SEG-004** | Validación de un solo nivel | Al verificar RN-SEG-003 | Se valida contra el padre inmediato, sin recorrer la cadena de ancestros: la contención es transitiva | Alta |
@@ -444,3 +444,4 @@ RNF-SEG-002 merece atención: es una prueba que enumera los endpoints registrado
 | 0.3.0 | 20-08-2026 | §8 pasa a definir `audit_security_log` como uno de los cuatro registros del Art. V.8: columnas propias, `target_user_id`, IP de origen y transacción independiente. §4.4 sustituye `audit:read` por cuatro permisos de lectura por tipo. Nuevo RNF-SEG-007 y pendientes D-20 y D-21. | Responsable técnico |
 | 0.4.0 | 20-08-2026 | Las reglas de §4.3 declaran cuándo aplican, qué debe ocurrir y su prioridad, conforme a la plantilla de requerimientos por módulo. | Responsable técnico |
 | 0.5.0 | 20-08-2026 | Se registra D-22: el alcance de datos es un eje ortogonal al permiso y carece de diseño. Lo evidencia la Épica 2, donde cinco de siete roles se definen por el alcance y no por el permiso. | Responsable técnico |
+| 0.6.0 | 20-08-2026 | RN-SEG-001 acota la unicidad de rol a los no eliminados lógicamente, lo que la convierte en un índice único parcial. | Responsable técnico |

--- a/docs/specs/.pages
+++ b/docs/specs/.pages
@@ -1,0 +1,4 @@
+title: Especificaciones
+nav:
+  - plantillas
+  - ...

--- a/docs/specs/plantillas/.pages
+++ b/docs/specs/plantillas/.pages
@@ -1,0 +1,5 @@
+title: Plantillas
+nav:
+  - spec.md
+  - plan.md
+  - tasks.md

--- a/docs/specs/plantillas/plan.md
+++ b/docs/specs/plantillas/plan.md
@@ -131,7 +131,7 @@ Esta sección es la que da valor al documento dentro de un año. Una alternativa
 
 ## 11. Estrategia de prueba
 
-Qué nivel cubre cada criterio de aceptación de `spec.md` §11:
+Qué nivel cubre cada criterio de aceptación de `spec.md` §12:
 
 | Criterio | Nivel | Qué verifica |
 |---|---|---|

--- a/docs/specs/plantillas/plan.md
+++ b/docs/specs/plantillas/plan.md
@@ -1,0 +1,140 @@
+# PLAN — `RF-XXX-NNN` [Nombre de la funcionalidad]
+
+| Campo | Valor |
+|---|---|
+| Requerimiento | `RF-XXX-NNN` |
+| Especificación | [`spec.md`](spec.md) |
+| `spec.md` aprobada el | [DD-MM-AAAA] |
+| Estado | Borrador · En revisión · **Aprobado** |
+| Autor | [Nombre] |
+| Aprobado por | [Responsable técnico] |
+| Fecha de aprobación | [DD-MM-AAAA] |
+
+!!! info "Qué va en este documento"
+
+    **Cómo se construye.** Las decisiones técnicas que la especificación deliberadamente no toma.
+
+    **Prueba de pertenencia:** si al negocio no le importa ni lo entendería, va aquí.
+
+    **No se empieza a escribir hasta que `spec.md` esté aprobada** (Art. I.6). Planear sobre una especificación que aún va a cambiar es donde más trabajo se pierde.
+
+---
+
+## 1. Enfoque
+
+[Dos o tres frases: cómo se va a resolver. Suficiente para que alguien entienda la forma de la solución antes de entrar al detalle.]
+
+## 2. Cambios de esquema
+
+**Migración:** `V<n>__<descripcion>.sql`
+
+| Tabla | Cambio | Detalle |
+|---|---|---|
+| [tabla] | Crea / Altera | [Columnas, tipos, restricciones] |
+
+Recordatorios que aplican siempre:
+
+- Clave primaria `uuid` v7 generada en la aplicación (Art. V.11).
+- `created_at` y `updated_at`; **sin** columnas de actor (Art. V.7).
+- Integridad declarada en el esquema: claves foráneas, `NOT NULL`, únicas y `CHECK` (Art. V.6).
+- Convenciones de nombre de `architecture.md` §6.2.
+
+Si no hay cambios de esquema, decirlo explícitamente.
+
+## 3. Componentes afectados
+
+| Capa | Componente | Nuevo / Modificado | Responsabilidad |
+|---|---|---|---|
+| `domain` | | | |
+| `application` | | | |
+| `infrastructure` | | | |
+| `api` | | | |
+
+Las reglas `RN-…` van en `domain` y deben poder probarse sin Spring ni base de datos (Art. VI.3).
+
+## 4. Contrato de API
+
+| Método | Ruta | Descripción |
+|---|---|---|
+| `POST` | `/api/v1/[recurso]` | [Qué hace] |
+
+**Petición**
+
+```json
+{ }
+```
+
+**Respuesta `2xx`**
+
+```json
+{ }
+```
+
+**Errores**
+
+| Código | Cuándo | `error_code` |
+|---|---|---|
+| `400` | [Condición] | `VAL-001` |
+| `409` | [Condición] | `RN-XXX-NNN` |
+
+El formato de error es el de `architecture.md` §7.3. Toda colección se pagina (§7.4).
+
+## 5. Autorización
+
+| Endpoint | Permiso requerido |
+|---|---|
+| [Método y ruta] | `recurso:acción` |
+
+Si el permiso no existe todavía en el catálogo, indicar en qué migración se crea. Un endpoint sin permiso declarado queda inaccesible (Art. IV.1).
+
+## 6. Auditoría
+
+Qué evento emite esta funcionalidad y a cuál de los cuatro registros del Art. V.8:
+
+| Operación | Registro | Contenido relevante |
+|---|---|---|
+| [Operación] | `audit_change_log` | Diff de los campos modificados |
+| [Eliminación] | `audit_deletion_log` | Motivo obligatorio y `snapshot` |
+| [Fallo] | `audit_error_log` | Código, tipo y severidad |
+| [Evento de acceso] | `audit_security_log` | Tipo de evento y `outcome` |
+
+Sin evento de auditoría, la autoría del cambio es irrecuperable (Art. V.7).
+
+## 7. Transaccionalidad
+
+| Elemento | Transacción |
+|---|---|
+| Cambio de negocio y su auditoría de cambio/eliminación | **La misma** (Art. V.14) |
+| Auditoría de error y de seguridad | **Independiente**, `REQUIRES_NEW` (Art. V.14) |
+
+## 8. Impacto sobre otros módulos
+
+| Módulo | Impacto |
+|---|---|
+| [Módulo] | [Qué cambia para él] |
+
+Ninguno accede a las tablas de otro: la comunicación es por interfaz publicada (`architecture.md` §5.3).
+
+## 9. Alternativas consideradas
+
+| Alternativa | Por qué se descartó |
+|---|---|
+| [Opción] | [Motivo] |
+
+Esta sección es la que da valor al documento dentro de un año. Una alternativa descartada sin motivo escrito se vuelve a proponer.
+
+## 10. Riesgos
+
+| Riesgo | Impacto | Mitigación |
+|---|---|---|
+| [Riesgo] | Alto / Medio / Bajo | [Qué se hace] |
+
+## 11. Estrategia de prueba
+
+Qué nivel cubre cada criterio de aceptación de `spec.md` §11:
+
+| Criterio | Nivel | Qué verifica |
+|---|---|---|
+| `CA-XXX-001` | Unitaria / Integración / API | [Qué] |
+
+Toda regla `RN-…` se prueba de forma unitaria y aislada.

--- a/docs/specs/plantillas/spec.md
+++ b/docs/specs/plantillas/spec.md
@@ -1,0 +1,126 @@
+# SPEC — `RF-XXX-NNN` [Nombre de la funcionalidad]
+
+| Campo | Valor |
+|---|---|
+| Requerimiento | `RF-XXX-NNN` |
+| Módulo | `XXX` — [Nombre del módulo] |
+| Estado | Borrador · En revisión · **Aprobada** |
+| Autor | [Nombre] |
+| Aprobada por | [Nombre] |
+| Fecha de aprobación | [DD-MM-AAAA] |
+
+!!! info "Qué va en este documento"
+
+    **Qué debe pasar, y por qué.** Nada más.
+
+    **Prueba de pertenencia:** si un cambio de tecnología lo invalidaría, no pertenece aquí — va a `plan.md`. No se nombran tablas, clases, endpoints ni librerías.
+
+    Debe poder leerlo alguien del negocio y entenderlo completo. Es la primera compuerta del Art. I.6: hasta que no esté aprobada, no se escribe `plan.md`.
+
+---
+
+## 1. Objetivo
+
+[Una o dos frases: qué necesidad resuelve esta funcionalidad. Si no puedes escribirlo sin mencionar tecnología, el objetivo todavía no está claro.]
+
+## 2. Contexto
+
+[Por qué se necesita ahora, qué existe hoy y qué problema concreto tiene. Quien lea esto dentro de un año debe entender la decisión sin preguntar.]
+
+## 3. Actores
+
+| Actor | Rol en esta funcionalidad |
+|---|---|
+| [Actor] | [Qué hace] |
+
+## 4. Alcance
+
+### 4.1 Incluye
+
+- [Comportamiento]
+
+### 4.2 No incluye
+
+- [Comportamiento que deliberadamente queda fuera, y a qué requerimiento pertenece]
+
+> El «no incluye» es tan importante como el «incluye»: es lo que evita que el alcance crezca durante la implementación.
+
+## 5. Reglas de negocio aplicables
+
+| ID | Regla | Origen |
+|---|---|---|
+| `RN-XXX-NNN` | [Enunciado] | [Documento donde está definida] |
+
+Las reglas **no se redefinen aquí**: se referencian. Si la funcionalidad exige una regla nueva, primero se agrega al documento del módulo.
+
+## 6. Datos
+
+Descritos en lenguaje de negocio. El tipo de columna, la longitud y el nombre físico se deciden en `plan.md`.
+
+### 6.1 Entrada
+
+| Dato | Obligatorio | Descripción | Restricción de negocio |
+|---|---|---|---|
+| [Dato] | Sí / No | [Qué significa] | [Qué valores admite y por qué] |
+
+### 6.2 Salida
+
+| Dato | Descripción |
+|---|---|
+| [Dato] | [Qué significa] |
+
+## 7. Flujo principal
+
+1. El actor [acción].
+2. El sistema [respuesta].
+3. El sistema [validación].
+4. El sistema [resultado].
+5. El sistema informa [qué].
+
+## 8. Flujos alternativos
+
+### FA-001 — [Nombre]
+
+**Cuándo ocurre:** [condición]
+
+1. [Paso]
+2. [Resultado]
+
+## 9. Excepciones
+
+### EX-001 — [Nombre]
+
+**Condición:** [qué la provoca]
+**Respuesta del sistema:** [qué hace y qué informa]
+
+## 10. Validaciones
+
+| ID | Validación | Mensaje esperado |
+|---|---|---|
+| `VAL-001` | [Qué se valida] | [Mensaje al usuario, en español] |
+
+## 11. Criterios de aceptación
+
+Cada criterio debe ser observable y verificable. Si contiene «rápido», «fácil» o «intuitivo», no es un criterio (Art. II.2).
+
+| ID | Criterio |
+|---|---|
+| `CA-XXX-001` | El sistema permite [acción verificable] |
+| `CA-XXX-002` | El sistema rechaza [condición inválida] con [respuesta concreta] |
+| `CA-XXX-003` | El sistema registra el evento de auditoría correspondiente |
+
+Cada uno tendrá al menos una prueba automatizada asociada (Art. II.4).
+
+## 12. Casos límite
+
+- [Qué pasa con el valor vacío, el máximo, la concurrencia, el registro inexistente, el actor sin permiso…]
+
+Los casos límite que no se enumeren aquí se descubrirán en producción.
+
+## 13. Preguntas abiertas
+
+| # | Pregunta | Responsable | Estado |
+|---|---|---|---|
+| 1 | [Pregunta] | [Quién decide] | Abierta / Resuelta |
+
+**Una spec con preguntas abiertas no puede aprobarse.** Esta sección debe quedar vacía antes de pasar la compuerta.

--- a/docs/specs/plantillas/spec.md
+++ b/docs/specs/plantillas/spec.md
@@ -69,7 +69,19 @@ Descritos en lenguaje de negocio. El tipo de columna, la longitud y el nombre f�
 |---|---|
 | [Dato] | [Qué significa] |
 
-## 7. Flujo principal
+## 7. Precondiciones y postcondiciones
+
+**Precondiciones** — lo que debe cumplirse **antes** de ejecutar la funcionalidad. Si alguna no se cumple, la funcionalidad no puede iniciarse.
+
+- [Condición]
+
+**Postcondiciones** — el estado en que queda el sistema **después** de una ejecución exitosa.
+
+- [Condición resultante]
+
+> Las precondiciones no son validaciones: una validación rechaza una entrada incorrecta; una precondición describe el estado del sistema que la funcionalidad da por supuesto.
+
+## 8. Flujo principal
 
 1. El actor [acción].
 2. El sistema [respuesta].
@@ -77,7 +89,7 @@ Descritos en lenguaje de negocio. El tipo de columna, la longitud y el nombre f�
 4. El sistema [resultado].
 5. El sistema informa [qué].
 
-## 8. Flujos alternativos
+## 9. Flujos alternativos
 
 ### FA-001 — [Nombre]
 
@@ -86,20 +98,20 @@ Descritos en lenguaje de negocio. El tipo de columna, la longitud y el nombre f�
 1. [Paso]
 2. [Resultado]
 
-## 9. Excepciones
+## 10. Excepciones
 
 ### EX-001 — [Nombre]
 
 **Condición:** [qué la provoca]
 **Respuesta del sistema:** [qué hace y qué informa]
 
-## 10. Validaciones
+## 11. Validaciones
 
 | ID | Validación | Mensaje esperado |
 |---|---|---|
 | `VAL-001` | [Qué se valida] | [Mensaje al usuario, en español] |
 
-## 11. Criterios de aceptación
+## 12. Criterios de aceptación
 
 Cada criterio debe ser observable y verificable. Si contiene «rápido», «fácil» o «intuitivo», no es un criterio (Art. II.2).
 
@@ -111,13 +123,13 @@ Cada criterio debe ser observable y verificable. Si contiene «rápido», «fác
 
 Cada uno tendrá al menos una prueba automatizada asociada (Art. II.4).
 
-## 12. Casos límite
+## 13. Casos límite
 
 - [Qué pasa con el valor vacío, el máximo, la concurrencia, el registro inexistente, el actor sin permiso…]
 
 Los casos límite que no se enumeren aquí se descubrirán en producción.
 
-## 13. Preguntas abiertas
+## 14. Preguntas abiertas
 
 | # | Pregunta | Responsable | Estado |
 |---|---|---|---|

--- a/docs/specs/plantillas/tasks.md
+++ b/docs/specs/plantillas/tasks.md
@@ -53,7 +53,7 @@ Las tareas sin dependencia entre sí pueden ejecutarse en paralelo.
 
 ## 3. Cobertura de los criterios de aceptación
 
-Toda fila de `spec.md` §11 debe aparecer aquí. Un criterio sin tarea que lo cubra es una funcionalidad que nadie va a implementar.
+Toda fila de `spec.md` §12 debe aparecer aquí. Un criterio sin tarea que lo cubra es una funcionalidad que nadie va a implementar.
 
 | Criterio | Tarea que lo cubre |
 |---|---|

--- a/docs/specs/plantillas/tasks.md
+++ b/docs/specs/plantillas/tasks.md
@@ -1,0 +1,80 @@
+# TASKS — `RF-XXX-NNN` [Nombre de la funcionalidad]
+
+| Campo | Valor |
+|---|---|
+| Requerimiento | `RF-XXX-NNN` |
+| Especificación | [`spec.md`](spec.md) |
+| Plan | [`plan.md`](plan.md) |
+| `plan.md` aprobado el | [DD-MM-AAAA] |
+| Estado | Borrador · En revisión · **Aprobadas** |
+| Issue | `#NN` |
+| Rama | `feature/[descripcion]` |
+| Aprobadas por | [Responsable técnico] |
+
+!!! info "Qué va en este documento"
+
+    **En qué pasos, en qué orden y cómo se verifica cada uno.**
+
+    **Prueba de pertenencia:** si no puede marcarse como hecho, no es una tarea.
+
+    **Es la fuente de verdad de las tareas.** El Issue de GitHub coordina y enlaza aquí; no la sustituye ni la duplica. Si las dos listas discrepan, manda este archivo.
+
+    No se escribe hasta que `plan.md` esté aprobado, y ninguna tarea se ejecuta hasta que este documento lo esté (Art. I.6).
+
+---
+
+## 1. Tareas
+
+Cada tarea debe ser del tamaño de un commit y tener una verificación objetiva. «Implementar el módulo» no es una tarea; «crear la migración `V4__create_roles.sql` y que `mvn flyway:info` la muestre aplicada» sí.
+
+| # | Tarea | Depende de | Verificación | Estado |
+|---|---|---|---|---|
+| `T-01` | [Migración de esquema] | — | `mvn flyway:info` la lista aplicada | Pendiente |
+| `T-02` | [Entidad de dominio y reglas `RN-…`] | `T-01` | Prueba unitaria en verde, sin Spring | Pendiente |
+| `T-03` | [Caso de uso y transaccionalidad] | `T-02` | Prueba con dobles en verde | Pendiente |
+| `T-04` | [Evento de auditoría] | `T-03` | Prueba de integración verifica la fila escrita | Pendiente |
+| `T-05` | [Repositorio y adaptador] | `T-02` | Prueba de integración con Testcontainers | Pendiente |
+| `T-06` | [Endpoint, DTOs y permiso] | `T-03` | Prueba de API cubre `2xx` y errores | Pendiente |
+| `T-07` | [Documentación OpenAPI] | `T-06` | El contrato publicado coincide con el real | Pendiente |
+| `T-08` | [Actualizar matriz de trazabilidad] | `T-06` | La fila del `RF` refleja el estado | Pendiente |
+
+**Estados:** `Pendiente` · `En curso` · `Hecha` · `Bloqueada`.
+
+## 2. Orden de ejecución
+
+```mermaid
+graph LR
+    T01[T-01] --> T02[T-02] --> T03[T-03] --> T04[T-04]
+    T02 --> T05[T-05]
+    T03 --> T06[T-06] --> T07[T-07] --> T08[T-08]
+```
+
+Las tareas sin dependencia entre sí pueden ejecutarse en paralelo.
+
+## 3. Cobertura de los criterios de aceptación
+
+Toda fila de `spec.md` §11 debe aparecer aquí. Un criterio sin tarea que lo cubra es una funcionalidad que nadie va a implementar.
+
+| Criterio | Tarea que lo cubre |
+|---|---|
+| `CA-XXX-001` | `T-06` |
+
+## 4. Bloqueos
+
+| # | Bloqueo | Desde | Responsable | Estado |
+|---|---|---|---|---|
+| 1 | [Qué impide avanzar] | [Fecha] | [Quién] | Abierto / Resuelto |
+
+## 5. Definición de terminado
+
+El requerimiento no está terminado hasta cumplir **todas** las condiciones de la constitución §16:
+
+- [ ] Todas las tareas en estado `Hecha`.
+- [ ] Todos los criterios de aceptación con prueba automatizada en verde.
+- [ ] `mvn verify` en verde en local.
+- [ ] Toda escritura emite su evento de auditoría, en la transacción que corresponde.
+- [ ] Los endpoints nuevos declaran su permiso.
+- [ ] El contrato OpenAPI coincide con el comportamiento real.
+- [ ] Documentación afectada actualizada en el mismo Pull Request.
+- [ ] Matriz de trazabilidad actualizada.
+- [ ] Pull Request aprobado por alguien distinto del autor e integrado.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -44,6 +44,7 @@ theme:
 plugins:
   - search:
       lang: es
+  - awesome-pages
 
 markdown_extensions:
   - abbr
@@ -72,14 +73,7 @@ markdown_extensions:
           class: mermaid
           format: !!python/name:pymdownx.superfences.fence_code_format
 
-nav:
-  - Inicio: index.md
-  - Constitución: constitution.md
-  - Arquitectura: architecture.md
-  - Seguridad: security.md
-  - Mapa modular: modules.md
-  - Requerimientos y trazabilidad: requirements.md
-  - Guía de desarrollo: development-guide.md
-
-# Al agregar un documento nuevo, incorporarlo a la navegación anterior.
-# La construccion se ejecuta con --strict: un enlace roto detiene el pipeline.
+# La navegación NO se declara aquí: la gestiona mkdocs-awesome-pages-plugin
+# a partir de los archivos .pages de cada carpeta. Ver docs/.pages.
+#
+# La construcción se ejecuta con --strict: un enlace roto detiene el pipeline.

--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -8,3 +8,4 @@
 mkdocs~=1.6
 mkdocs-material~=9.5
 pymdown-extensions~=10.11
+mkdocs-awesome-pages-plugin~=2.9


### PR DESCRIPTION
## Requerimiento
No aplica en su mayor parte: base documental. Incluye además los 21
requerimientos del módulo SP (RF-SP-001 a RF-SP-021), ya registrados en la
matriz de trazabilidad.

## Descripción del cambio
- Documentación técnica completa en el repositorio, publicada como sitio MkDocs.
- Constitución v0.7.0, arquitectura v0.5.0, seguridad v0.7.0, guía v0.4.0,
  mapa modular v0.7.0, trazabilidad v0.5.0.
- Metodología SDD con tripleta spec/plan/tasks y tres compuertas de aprobación.
- Auditoría separada en cuatro registros especializados.
- requirements/sp.md v1.0.0, primer documento aprobado del proyecto.

## Evidencia de pruebas
mkdocs build --strict en verde. Sin código todavía, por tanto sin pruebas
automatizadas.

## Impacto técnico
- Requiere habilitar GitHub Pages con origen "GitHub Actions".
- El sitio se publica desde develop, no desde main.

## Consideraciones adicionales
- Quedan pendientes D-09 a D-11, D-16 a D-22.
- El inventario de módulos está incompleto: solo SP y USR.
- Falta testing-strategy.md.