### PR TITLE
ci: publicar el sitio desde main y no desde develop

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ name: Documentación
 #
 # En Pull Request solo construye: verifica que la documentación sigue siendo
 # válida —enlaces, navegación, sintaxis— antes de integrar.
-# En develop construye y publica.
+# En main construye y publica.
 #
 # Se publica desde develop y no desde main porque la documentación técnica vale
 # por estar al día: con el flujo feature -> develop -> main, main puede llevar
@@ -14,7 +14,7 @@ name: Documentación
 
 on:
   push:
-    branches: [develop]
+    branches: [main]
     paths:
       - "docs/**"
       # Los archivos .pages controlan la navegación del sitio y empiezan por
@@ -69,14 +69,14 @@ jobs:
         run: mkdocs build --strict
 
       - name: Publicar el artefacto
-        if: github.ref == 'refs/heads/develop'
+        if: github.ref == 'refs/heads/main'
         uses: actions/upload-pages-artifact@v3
         with:
           path: site
 
   desplegar:
     name: Desplegar en GitHub Pages
-    if: github.ref == 'refs/heads/develop'
+    if: github.ref == 'refs/heads/main'
     needs: construir
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
El despliegue fallaba con "Branch develop is not allowed to deploy to github-pages due to environment protection rules".

El entorno github-pages de GitHub solo admite por defecto la rama por defecto del repositorio, que es main. Configurarlo para publicar desde develop hacia que la construccion pasara y el despliegue se rechazara despues, sin que el error fuera evidente hasta ejecutarlo.

La razon por la que se habia elegido develop era evitar que el sitio quedara retrasado, dando por hecho que main tardaria en recibir los cambios. No es el caso: develop se integra en main con normalidad, de modo que el argumento no se sostenia.

edit_uri en mkdocs.yml sigue apuntando a develop, y es correcto: se edita en develop y se publica al integrar en main. Nadie edita main directamente (Art. III.2).

Queda anotado en la cabecera del flujo que publicar desde otra rama exige ampliar "Deployment branches" en Settings, Environments, github-pages. Sin ese ajuste el despliegue se rechaza aunque la construccion este en verde.