### PR TITLE
release: request_log y permisos por endpoint verificados (#23, #26)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,9 @@ jobs:
       - name: Verificar
         run: mvn -B verify
 
-      # `OpenApiContractIT` reescribe docs/api/openapi.json durante `verify`.
+      # `OpenApiContractIT` reescribe docs/api/openapi.json y openapi.yaml
+      # durante `verify`. Los dos: el JSON se lee, y el YAML es lo que piden por
+      # defecto los generadores de cliente del frontend.
       # Si lo que acaba de generarse no coincide con lo comprometido, es que
       # alguien cambió un endpoint y no regeneró el contrato: el Art. VIII.6
       # trata esa divergencia como defecto, y aquí es donde se convierte en
@@ -69,9 +71,9 @@ jobs:
       # comprobado nada.
       - name: El contrato publicado está al día
         run: |
-          git add -N docs/api/openapi.json
-          git diff --exit-code -- docs/api/openapi.json \
-            || { echo "::error::El contrato ha cambiado. Ejecuta 'mvn verify' y commitea docs/api/openapi.json."; exit 1; }
+          git add -N docs/api/openapi.json docs/api/openapi.yaml
+          git diff --exit-code -- docs/api/openapi.json docs/api/openapi.yaml \
+            || { echo "::error::El contrato ha cambiado. Ejecuta 'mvn verify' y commitea docs/api/."; exit 1; }
 
       - name: Publicar el informe de cobertura
         if: always()

--- a/docs/.pages
+++ b/docs/.pages
@@ -11,6 +11,7 @@ nav:
   - Modelo de datos: modelo-datos.md
   - Requerimientos y trazabilidad: requirements.md
   - flujos
+  - Contrato de la API: api/index.md
   - Guía de desarrollo: development-guide.md
   - specs
   - ...

--- a/docs/api/.pages
+++ b/docs/api/.pages
@@ -1,0 +1,3 @@
+title: Contrato de la API
+nav:
+  - index.md

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,82 @@
+# El contrato de la API
+
+| Campo | Valor |
+|---|---|
+| Proyecto | NEXUS — Renovación de plataforma |
+| Empresa | FACTECH GROUP SAS |
+| Documento | `api/index.md` |
+| Versión | 1.0.0 |
+| Estado | Publicado |
+| Responsable técnico | Bonilla Diaz William Steven |
+| Fecha de creación | 25-08-2026 |
+| Última actualización | 25-08-2026 |
+| Documento superior | `architecture.md` v0.14.0 |
+
+---
+
+## 1. Dónde está
+
+La especificación OpenAPI de **todas** las rutas se publica como archivo versionado, en los dos formatos, y **no exige credenciales ni que haya nada en ejecución**:
+
+| Formato | URL |
+|---|---|
+| JSON | <https://nexuspro-dev.github.io/backend/api/openapi.json> |
+| YAML | <https://nexuspro-dev.github.io/backend/api/openapi.yaml> |
+
+En el repositorio son `docs/api/openapi.json` y `docs/api/openapi.yaml`.
+
+El Art. VIII.7 hace de esta especificación el **único** contrato entre backend y frontend: no deben acordarse comportamientos por fuera de ella. Si algo que el frontend necesita no está aquí, la respuesta correcta no es escribirlo a mano en el cliente sino **abrir un issue en este repositorio**.
+
+## 2. Por qué un archivo y no una instancia en ejecución
+
+Porque atar la construcción del frontend a que haya un backend levantado hace que un Pull Request suyo deje de ser reproducible, y en un entorno sin red no se pueda construir. Es la decisión de [`ADR-001`](../architecture/ADR-001-publicacion-del-contrato-openapi.md).
+
+**`/v3/api-docs` y Swagger UI siguen cerrados en los entornos desplegados** (`EXPOSE_API_DOCS` en `false`). Que el contrato sea legible aquí no autoriza a dejar Swagger abierto donde hay datos reales, donde además invita a probar contra ellos. En **local** sí están abiertos: `docker-compose.yml` fija la bandera en `true`, de modo que quien levante el entorno tiene `http://localhost:8080/swagger-ui.html`.
+
+## 3. Cómo se mantiene al día
+
+No a mano. `OpenApiContractIT` **reescribe** los dos archivos durante `mvn verify`, y CI falla si lo comprometido no coincide con lo generado (Art. VIII.6). Eso convierte en pipeline en rojo lo que de otro modo sería un contrato que envejece sin que nadie lo note.
+
+En la práctica: **quien cambia un endpoint ejecuta `mvn verify` y commitea `docs/api/`**. No hay un paso manual de publicación.
+
+## 4. Lo que el cliente necesita saber
+
+**Base.** Todas las rutas cuelgan de `/api/v1`. La URL del servidor depende del entorno y **no** viaja en el contrato: se configura en el cliente.
+
+**Autenticación.** `Bearer` con JWT en la cabecera `Authorization`. El contrato lo declara como esquema global, de modo que **toda operación lo exige salvo tres**: `POST /auth/login`, `POST /auth/refresh` y `POST /auth/logout`, que no pueden pedir el token que aún no se tiene —o que ya no se tiene—.
+
+**El token de acceso dura quince minutos** y no es revocable: solo expira. El refresco rota el token de refresco en cada uso, así que el cliente debe **guardar el nuevo y descartar el anterior**; reutilizar uno ya usado se interpreta como robo y revoca la familia entera.
+
+**CORS.** El navegador solo puede leer la respuesta desde un origen autorizado, y la lista se declara por entorno en `CORS_ALLOWED_ORIGINS` (`security.md` §6.1). En un despliegue nuevo **está vacía**, que es el valor seguro: si el frontend no puede llamar, es lo primero que hay que mirar. La respuesta expone `Location` y `X-Correlation-Id`.
+
+**Errores.** Formato RFC 9457 uniforme (`architecture.md` §7.3), con `correlationId` siempre presente: es el identificador que conviene mostrar al usuario cuando algo falla, porque es con el que el equipo lo localiza.
+
+**Paginación.** Los listados devuelven `content`, `page`, `size`, `totalElements`, `totalPages` y **`totalIsExact`**. Ese último importa: en los registros de auditoría el total es exacto **hasta un techo** y aproximado por encima, y `totalPages` es entonces una cota inferior — pedir una página más allá sigue funcionando (`architecture.md` §7.4).
+
+**Límite de tasa.** Los tres endpoints públicos de autenticación están acotados y responden `429` con `Retry-After` y `retryAfterSeconds`. El cliente debe **descontar** esos segundos y no calcular la espera con su propio reloj.
+
+## 5. Generar el cliente
+
+Con cualquier generador que acepte una URL. Por ejemplo:
+
+```bash
+npx @hey-api/openapi-ts \
+  -i https://nexuspro-dev.github.io/backend/api/openapi.yaml \
+  -o src/api
+```
+
+Se recomienda **fijar la generación en la construcción** del frontend y no commitear el cliente generado editado a mano: en cuanto se toca, deja de ser un reflejo del contrato y vuelve el acuerdo por fuera que el Art. VIII.7 prohíbe.
+
+## 6. Lo que el contrato todavía no dice
+
+Conviene saberlo antes de tropezar:
+
+- **El `429` del límite de tasa no está documentado por endpoint.** Lo produce un filtro, que no pasa por las anotaciones del controlador. El comportamiento existe y es el descrito arriba; la anotación falta.
+- **El `423` de cuenta bloqueada y el cuerpo del `429`** están en curso en el trabajo de `RF-SP-034`.
+- **No hay endpoint de recuperación de contraseña**: `RF-SP-040` está bloqueado por la decisión **D-23**, el mecanismo del canal de envío.
+
+## 7. Control de cambios
+
+| Versión | Fecha | Cambio | Responsable |
+|---|---|---|---|
+| 1.0.0 | 25-08-2026 | Se publica esta página. El contrato ya se versionaba desde `ADR-001`, pero **nada decía dónde encontrarlo ni cómo consumirlo**, de modo que el frontend tenía el archivo y no la instrucción. Se añade además el **YAML**, que es el formato que asumen por defecto los generadores de cliente: publicar solo el JSON obligaba a cada consumidor a convertirlo, y una conversión hecha en el lado del cliente es una copia del contrato que envejece por su cuenta. | Responsable técnico |

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,3578 @@
+openapi: 3.1.0
+info:
+  title: NEXUS — API del Sistema Principal
+  description: |
+    API del módulo `SP`. **Toda operación exige un token de acceso**
+    salvo el inicio, la renovación y el cierre de sesión.
+
+    Para probar cualquier endpoint: obtenga el token con
+    `POST /api/v1/auth/login`, pulse **Authorize** y pegue el valor de
+    `accessToken` — sin el prefijo `Bearer`, que Swagger añade solo.
+
+    El token vive **quince minutos** y no es revocable: cuando expire,
+    renuévelo con `POST /api/v1/auth/refresh` y vuelva a autorizar.
+  version: v1
+servers:
+- url: /
+  description: Este mismo servidor
+security:
+- bearerAuth: []
+tags:
+- name: Roles
+  description: Registro y administración de los roles del sistema.
+- name: Usuarios
+  description: Alta y administración de las personas del sistema.
+- name: Permisos
+  description: Catálogo de permisos del sistema. Solo lectura.
+- name: Auditoría
+  description: "Los cuatro registros de auditoría del sistema. Solo lectura, y cada\
+    \ uno con su permiso."
+- name: Países
+  description: Catálogo de países. Inmutable salvo su estado.
+- name: Membresías
+  description: Cadena lineal de niveles de consumidor. Inmutable salvo el reordenamiento.
+- name: Monedas
+  description: Catálogo de monedas. Inmutable por API salvo su estado.
+- name: Sesión
+  description: "Inicio, renovación y cierre de sesión."
+paths:
+  /api/v1/users/{id}/membership:
+    put:
+      tags:
+      - Usuarios
+      summary: Fijar la membresía de una persona
+      description: |
+        **`PUT` y no `POST`**, al revés que la asignación de roles, y la
+        diferencia no es de gusto: aquí el cuerpo **sí** representa el estado
+        final. La persona tiene una membresía o ninguna, de modo que enviar una
+        la deja como la única — y de ahí sale gratis la idempotencia.
+
+        `endsAt` es opcional. **Ausente significa indefinida**: enviarlo ausente
+        sobre una membresía que tenía fecha la convierte en indefinida, y es un
+        caso normal, no un olvido que haya que interpretar. Presente, la
+        membresía deja de estar vigente **al llegar** ese instante, no después.
+
+        Repetir la petición idéntica no escribe ni deja auditoría. Cambiar solo
+        la fecha sí es un cambio y sí se registra.
+
+        Devuelve `200` incluso la primera vez: `PUT` sobre una ruta fija no crea
+        un recurso direccionable nuevo.
+      operationId: fijarMembresia
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignMembershipRequest"
+        required: true
+      responses:
+        "200":
+          description: "La membresía, con su nivel y su vigencia."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserMembershipResponse"
+        "400":
+          description: "Membresía ausente o malformada (`VAL-001`), o fecha de fin\
+            \ igual o anterior al momento de la asignación (`VAL-005`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:assign-membership` (`AUTH-002`)
+        "404":
+          description: La persona no existe o está eliminada (`VAL-004`)
+        "409":
+          description: La persona no porta ningún rol de consumidor (`RN-SP-013`).
+            El cuerpo indica que primero corresponde asignarle uno
+        "422":
+          description: La membresía indicada no existe en la cadena (`VAL-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+    delete:
+      tags:
+      - Usuarios
+      summary: Retirar la membresía de una persona
+      description: |
+        **Rechaza a quien SÍ es consumidor**, que es lo contrario de lo que
+        sugiere el nombre. No existe el estado «consumidor sin nivel», de modo
+        que esta operación solo sirve para **corregir un estado incoherente**:
+        alguien con membresía que ya no porta ningún rol de consumidor.
+
+        Las dos salidas reales para un consumidor en activo son bajarlo de nivel
+        con la operación de membresía, o retirarle el rol — el retiro arrastra la
+        membresía por su cuenta. El cuerpo del `409` las cita.
+
+        Sin membresía previa devuelve `204` igual: la operación es idempotente y
+        su resultado ya se cumplía.
+
+        **Conserva el `DELETE`** y no le alcanza la enmienda del retiro de
+        roles: esta operación no lleva cuerpo, de modo que el problema que
+        aquella evitaba no existe aquí.
+      operationId: retirarMembresia
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "204":
+          description: Membresía retirada.
+        "400":
+          description: Identificador malformado (`VAL-001`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:assign-membership` (`AUTH-002`)
+        "404":
+          description: La persona no existe o está eliminada (`VAL-002`)
+        "409":
+          description: La persona porta al menos un rol de consumidor (`RN-SP-018`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users:
+    get:
+      tags:
+      - Usuarios
+      summary: Consultar personas
+      description: |
+        Listado paginado con filtros, búsqueda y ordenamiento.
+
+        **El orden por defecto es `lastName,asc`** y no el nombre de usuario:
+        esta es la lista desde la que se administra el acceso, y quien la mira
+        busca a alguien por su apellido.
+
+        Solo se puede ordenar por la lista blanca —`username`, `email`,
+        `firstName`, `lastName`, `status`, `createdAt`, `updatedAt`—. **No se
+        admite ordenar por ningún campo de la credencial**: ordenar por la marca
+        de cambio obligatorio produciría la lista de quien no ha cambiado su
+        contraseña inicial.
+
+        **`roleId` y `membershipId` no se validan contra su catálogo.** Un
+        filtro por algo inexistente devuelve la colección vacía y no es un
+        error.
+
+        La búsqueda va sobre nombre de usuario, correo y nombre completo,
+        **sin distinguir acentos ni mayúsculas**, y por fragmento.
+
+        `membership` **no es nula cuando está vencida**: vencer no es lo mismo
+        que no tener. `current` dice cuál de los dos casos es.
+
+        Un filtro sin coincidencias devuelve `200` con la colección vacía. No
+        hay `404` ni `422`.
+      operationId: listar
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: sort
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: roleId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: membershipId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: search
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: includeDeleted
+        in: query
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Página de personas.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponse"
+        "400":
+          description: "Paginación fuera de límites (`VAL-001`, `VAL-002`), campo\
+            \ de ordenamiento no admitido (`VAL-003`), o estado fuera de su dominio\
+            \ (`VAL-004`). Se devuelven **juntos**"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:read` (`AUTH-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+    post:
+      tags:
+      - Usuarios
+      summary: Registrar una persona
+      description: |
+        Registra una persona con sus roles iniciales.
+
+        La cuenta nace **activa** y **marcada para cambio obligatorio de
+        contraseña**: quien prepara el alta conoce la credencial, y esa ventana
+        se cierra en el primer inicio de sesión. Ni el estado ni la marca se
+        envían; enviarlos devuelve `400`.
+
+        **La membresía y el superior son condicionales en los dos sentidos.**
+        Un rol de consumidor exige membresía y la membresía exige un rol de
+        consumidor; lo mismo con el rol de vendedor y el superior comercial.
+        Indicar uno sin el otro devuelve `409`, no se ignora.
+
+        El superior debe portar el **rol padre inmediato** del rol vendedor de
+        mayor rango de la persona, y estar activo.
+
+        La contraseña no se recorta: un espacio al principio o al final es parte
+        de ella.
+      operationId: registrar
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterUserRequest"
+        required: true
+      responses:
+        "201":
+          description: Persona registrada. `Location` apunta a su detalle.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          description: "Formato u obligatoriedad incumplidos, contraseña que no cumple\
+            \ la política, o campo no admitido en el cuerpo"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin el permiso de creación de usuarios (`AUTH-002`)
+        "409":
+          description: "Identidad ya en uso (`RN-SP-016`), rol que excede los privilegios\
+            \ del actor (`RN-SEG-010`), consumidor sin membresía o al revés (`RN-SP-018`),\
+            \ vendedor sin superior o al revés (`RN-SP-019`), o superior que no porta\
+            \ el rol padre (`RN-SP-020`)"
+        "422":
+          description: Algún rol no existe o no está activo (`EX-003`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/{id}/roles:
+    post:
+      tags:
+      - Usuarios
+      summary: Asignar roles a una persona
+      description: |
+        Agrega roles. **No reemplaza la lista**: por eso es un `POST` sobre un
+        subrecurso y no un `PUT`. Un reemplazo haría retiros implícitos que se
+        saltarían tres reglas cuyo incumplimiento nadie vería.
+
+        Pedir un rol que la persona ya tiene no es un error: no cambia nada y
+        no deja rastro en la auditoría.
+
+        `membershipId`, `membershipEndsAt` y `supervisorId` son
+        **condicionales**: obligatorios exactamente cuando la operación
+        convierte a la persona en consumidor o cambia su rango comercial, y no
+        admitidos en cualquier otro caso. Su admisibilidad depende del estado
+        de la persona y no del cuerpo, de modo que su incumplimiento es `422` y
+        nunca `400`.
+
+        Un **ascenso** —que cambia el rol vendedor de mayor rango— exige
+        declarar de nuevo el superior: el anterior puede haber dejado de ser
+        admisible sin que nadie tocara esa fila.
+      operationId: asignarRoles
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignRolesRequest"
+        required: true
+      responses:
+        "200":
+          description: La persona con su estructura actualizada.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          description: "Lista vacía, identificador malformado o más de 100 elementos"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:assign-roles` (`AUTH-002`)
+        "404":
+          description: La persona no existe o está eliminada (`VAL-006`)
+        "409":
+          description: Algún rol concede permisos que el actor no posee (`RN-SEG-010`).
+            El cuerpo enumera cuáles
+        "422":
+          description: "Rol inexistente (`EX-002`), rol inactivo (`EX-003`), consumidor\
+            \ sin membresía (`RN-SP-018`), membresía indicada sin que corresponda\
+            \ (`EX-006`), vendedor sin superior (`RN-SP-019`), o superior inadmisible\
+            \ (`VAL-007`, `RN-SP-020`)"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/{id}/roles/revocations:
+    post:
+      tags:
+      - Usuarios
+      summary: Retirar roles de una persona
+      description: |
+        Retira roles y **arrastra las cascadas**: quedarse sin ningún rol de
+        consumidor borra la membresía, y quedarse sin ningún rol de vendedor
+        cierra la asignación de superior comercial —cerrarla, nunca borrarla:
+        esa fila dice a quién se atribuía cada resultado—.
+
+        **Revoca todas las sesiones de la persona.** Asignar no lo hace;
+        retirar sí, porque el refresh token sobrevive al cambio de permisos y
+        dejaría vivo hasta siete días el acceso que se acaba de quitar.
+
+        Es un `POST` sobre un subrecurso y no un `DELETE`: la lista viaja en el
+        cuerpo, y RFC 9110 no define semántica para el cuerpo de un `DELETE` —
+        un intermediario puede descartarlo sin avisar, y el retiro llegaría sin
+        roles.
+
+        **No se pide motivo** y **no se comprueba que los roles existan**:
+        retirar un rol eliminado del catálogo es legítimo, porque la asignación
+        sigue ahí y debe poder soltarse.
+      operationId: retirarRoles
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RevokeRolesRequest"
+        required: true
+      responses:
+        "200":
+          description: La persona con su estructura actualizada.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          description: "Lista vacía, identificador malformado o más de 100 elementos"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:assign-roles` (`AUTH-002`)
+        "404":
+          description: La persona no existe o está eliminada (`VAL-006`)
+        "409":
+          description: "El retiro dejaría al sistema sin superadministrador activo\
+            \ (`RN-SP-001`), algún rol excede los permisos del actor (`RN-SEG-010`),\
+            \ o la persona tiene equipo a cargo (`RN-SP-022`) — este último informa\
+            \ cuántas personas, nunca quiénes"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/{id}/password-reset:
+    post:
+      tags:
+      - Usuarios
+      summary: Restablecer la contraseña de una persona
+      description: |
+        Fija una credencial **provisional** sobre la cuenta indicada. `POST`
+        sobre un subrecurso y no `PATCH` sobre el usuario: cada petición **crea**
+        un restablecimiento, que es un hecho con fecha y con caducidad propia.
+
+        **La credencial CADUCA.** Sin plazo, una cuenta restablecida y nunca
+        usada conserva indefinidamente una contraseña que otra persona conoce, y
+        nadie se entera porque no falla nada. Quien comprueba el plazo es el
+        inicio de sesión.
+
+        La cuenta queda marcada para **cambio obligatorio**: la ventana en que
+        dos personas conocen la misma contraseña se cierra en el primer inicio
+        de sesión.
+
+        **No toca el estado ni el bloqueo**: restablecer no es reactivar. Una
+        cuenta desactivada sigue desactivada.
+
+        **La contraseña asignada no se devuelve**: la conoce quien la escribió, y
+        repetirla la expondría a cualquier registro de la operación. Tampoco la
+        fecha de caducidad — quien la necesite consulta el detalle.
+
+        Revoca **todas** las sesiones de la persona.
+      operationId: restablecerContrasena
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ResetPasswordRequest"
+        required: true
+      responses:
+        "204":
+          description: Credencial fijada.
+        "400":
+          description: Contraseña ausente (`VAL-001`) o que no cumple la política
+            (`VAL-002`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:reset-password` (`AUTH-002`)
+        "404":
+          description: La persona no existe o está eliminada (`VAL-004`)
+        "409":
+          description: "Es la cuenta del propio actor (`RN-SP-017`). El mensaje indica\
+            \ cuál es la operación correcta: cambiar la propia contraseña, que exige\
+            \ conocer la actual"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/{id}/deletion:
+    post:
+      tags:
+      - Usuarios
+      summary: Eliminar a una persona
+      description: |
+        Eliminación **lógica** y con motivo declarado. `POST` sobre un
+        subrecurso y no `DELETE` con cuerpo: RFC 9110 no define semántica para
+        el cuerpo de un `DELETE` y un intermediario puede descartarlo,
+        convirtiendo la petición en un rechazo por motivo ausente que el actor
+        no puede entender. Y tampoco por *query string*, o el motivo acabaría en
+        los registros de acceso de los proxies.
+
+        **El motivo se verifica el primero de todo**, antes incluso de saber si
+        la persona existe.
+
+        La operación **retira sus roles y su membresía**, **cierra** su
+        asignación de superior —cerrarla, nunca borrarla: es historial de
+        mando— y **revoca sus sesiones**, todo en la misma transacción y con la
+        misma marca de tiempo.
+
+        **El estado NO se toca**: se conserva como estaba para que el registro
+        de eliminación diga en qué situación estaba la persona cuando se la
+        eliminó.
+
+        El `404` **no distingue** «nunca existió» de «ya estaba eliminada».
+      operationId: eliminar
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteUserRequest"
+        required: true
+      responses:
+        "204":
+          description: Persona eliminada.
+        "400":
+          description: "Motivo ausente o vacío (`VAL-001`), o campo desconocido"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: "Autenticado sin `users:delete` (`AUTH-002`), o es la cuenta\
+            \ del propio actor (`RN-SP-017`)"
+        "404":
+          description: "No existe, o ya estaba eliminada (`EX-004`)"
+        "409":
+          description: "Es el último superadministrador activo (`RN-SP-001`), o tiene\
+            \ personas a cargo (`RN-SP-022`)"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/roles:
+    get:
+      tags:
+      - Roles
+      summary: Consultar roles
+      description: |
+        Listado paginado con filtros, búsqueda y ordenamiento. Es la entrada
+        natural a la administración de accesos: de aquí se navega al detalle de
+        cada rol.
+
+        **El orden por defecto es `code,asc`**: el código es el identificador
+        con el que se habla de un rol en la documentación y en la auditoría.
+        Solo se puede ordenar por la lista blanca —`code`, `name`, `roleType`,
+        `status`, `createdAt`, `updatedAt`—; cualquier otro campo devuelve
+        `400` y **no llega a la base de datos**.
+
+        **No incluye los permisos de cada rol** ni el número de usuarios
+        asignados: la primera pregunta la responde el detalle
+        (`GET /api/v1/roles/{id}`) y la segunda se hace sobre un rol concreto,
+        no sobre la lista.
+
+        **`parentRoleId` no se valida contra el catálogo.** Filtra por el padre
+        **directo** —no por el subárbol— y uno inexistente devuelve la
+        colección vacía, que no es un error.
+
+        La búsqueda va sobre código y nombre, **sin distinguir acentos ni
+        mayúsculas**, y por fragmento: `academico` encuentra
+        `LIDER_ACADEMICO`. Un término en blanco equivale a no filtrar.
+
+        **Los eliminados quedan fuera salvo que se pidan** con
+        `includeDeleted=true`; cuando se piden, `deletedAt` es lo que permite
+        distinguirlos.
+      operationId: listar_1
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: sort
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: status
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: roleType
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: parentRoleId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: search
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: includeDeleted
+        in: query
+        required: false
+        schema:
+          type: boolean
+      responses:
+        "200":
+          description: Página de roles.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponse"
+        "400":
+          description: "Paginación fuera de límites, campo de ordenamiento no admitido\
+            \ (`VAL-003`), o `status`/`roleType` fuera de su dominio (`VAL-004`).\
+            \ Se evalúan y se devuelven **juntos** en `errors`"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `roles:read` (`AUTH-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+    post:
+      tags:
+      - Roles
+      summary: Registrar un rol
+      description: |
+        Registra un rol bajo un rol padre existente y activo, con los permisos que
+        se declaren.
+
+        Los permisos deben estar contenidos en los del rol padre (`RN-SEG-003`) y en
+        los permisos efectivos de quien ejecuta el alta (`RN-SEG-010`). Declararlos es
+        opcional: sin ellos el rol queda registrado y a la espera de `RF-SP-005`.
+
+        El rol nace siempre **activo** y nunca de sistema. Ni `status` ni `isSystem`
+        se admiten en el cuerpo: enviarlos devuelve `400`.
+      operationId: registrar_1
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateRoleRequest"
+        required: true
+      responses:
+        "201":
+          description: Rol registrado. La cabecera `Location` lleva su dirección.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "400":
+          description: "Formato u obligatoriedad incumplidos (`VAL-001` a `VAL-004`,\
+            \ `VAL-007`, `VAL-008`), o el cuerpo trae un campo que este endpoint no\
+            \ admite"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `roles:create` (`AUTH-002`)
+        "409":
+          description: "Código o nombre ya en uso (`RN-SEG-001`), permiso fuera del\
+            \ rol padre (`RN-SEG-003`) o fuera del alcance del actor (`RN-SEG-010`)"
+        "422":
+          description: "El rol padre no existe o no está activo (`EX-002`), o algú\
+            n permiso no está en el catálogo (`EX-005`)"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/roles/{id}/permissions:
+    post:
+      tags:
+      - Roles
+      summary: Agregar permisos a un rol
+      description: |
+        Asocia permisos al rol. **La operación se aplica entera o no se
+        aplica**: un solo permiso que incumpla la contención rechaza la
+        petición completa, porque aplicar los válidos dejaría el rol en un
+        estado que nadie pidió.
+
+        Cada permiso debe estar **contenido en los del rol padre**
+        (`RN-SEG-003`) y **en los permisos efectivos de quien ejecuta la
+        operación** (`RN-SEG-010`). Lo segundo no lo concede `roles:update`:
+        ese permiso habilita a modificar roles, no a decidir con qué alcance.
+
+        **El rol raíz omite la primera comprobación** —no tiene cota superior—
+        y conserva la segunda.
+
+        **Es idempotente y nunca retira nada**: los permisos ya declarados se
+        ignoran sin error, y si no queda ninguno por agregar no se registra
+        evento. Hasta 100 por petición.
+      operationId: agregarPermisos
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RolePermissionsRequest"
+        required: true
+      responses:
+        "200":
+          description: Rol con sus permisos actualizados.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "400":
+          description: Sin permisos (`VAL-001`) o más de 100 (`VAL-006`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "403":
+          description: "Sin `roles:update`, o el rol está asignado al propio actor\
+            \ (`RN-SEG-011`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "404":
+          description: El rol no existe o está eliminado (`EX-006`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "409":
+          description: "Rol de sistema (`RN-SEG-012`), permiso fuera del rol padre\
+            \ (`RN-SEG-003`) o fuera del alcance del actor (`RN-SEG-010`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "422":
+          description: Uno o más permisos no existen en el catálogo (`EX-003`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+  /api/v1/roles/{id}/permissions/revocations:
+    post:
+      tags:
+      - Roles
+      summary: Retirar permisos de un rol
+      description: |
+        Desasocia permisos del rol, con **eliminación física** de la asociación
+        y **sin exigir motivo**: es una asociación y no una entidad de negocio.
+
+        **Se rechaza si un rol hijo directo declara alguno de los permisos que
+        se retiran** (`RN-SEG-005`), y el error dice **qué rol** declara **qué
+        permiso**: sin ese detalle no habría forma de saber qué corregir. Los
+        hijos **inactivos cuentan igual** que los activos —el invariante vale
+        siempre—, y los eliminados no.
+
+        **No hay cascada**: nunca se retiran permisos de los descendientes.
+        Usted decide en qué orden hacerlo.
+
+        **Es idempotente**: los permisos que el rol no declaraba se ignoran sin
+        error. Hasta 100 por petición, el mismo límite que al agregarlos.
+
+        **`POST` sobre un subrecurso y no `DELETE`**: la operación recibe una
+        lista en el cuerpo, y RFC 9110 no define semántica para el cuerpo de un
+        `DELETE`.
+      operationId: retirarPermisos
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RolePermissionsRequest"
+        required: true
+      responses:
+        "200":
+          description: Rol con sus permisos actualizados.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "400":
+          description: Sin permisos (`VAL-001`) o más de 100 (`VAL-004`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "403":
+          description: "Sin `roles:update`, o el rol está asignado al propio actor\
+            \ (`RN-SEG-011`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "404":
+          description: El rol no existe o está eliminado (`EX-004`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "409":
+          description: "Rol de sistema (`RN-SEG-012`), o un rol dependiente declara\
+            \ el permiso (`RN-SEG-005`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+  /api/v1/roles/{id}/deletion:
+    post:
+      tags:
+      - Roles
+      summary: Eliminar un rol
+      description: |
+        Elimina lógicamente el rol. **El motivo es obligatorio** y se verifica
+        **antes de ejecutar nada** (Art. V.13); no se admite un valor generado
+        por el sistema.
+
+        **Se rechaza si el rol tiene roles hijos vigentes** —diciendo cuáles— o
+        **personas asignadas** —diciendo cuántas— (`RN-SEG-008`). En el segundo
+        caso la respuesta sugiere **desactivar** el rol, que suele ser lo que
+        en realidad se quería: retirar el acceso sin perder el rol. El conteo
+        incluye a las personas inactivas y bloqueadas, y excluye a las
+        eliminadas.
+
+        Tras eliminarlo, **su código y su nombre quedan libres** para un rol
+        nuevo, y el rol deja de aparecer en el listado por defecto. La
+        auditoría de eliminación conserva el motivo y el rol completo —con sus
+        permisos por código— para poder reconstruir qué era.
+
+        **`POST` sobre un subrecurso y no `DELETE`**: el motivo viaja en el
+        cuerpo, y un intermediario puede descartar el cuerpo de un `DELETE`.
+      operationId: eliminar_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteRoleRequest"
+        required: true
+      responses:
+        "204":
+          description: Rol eliminado. Sin cuerpo.
+        "400":
+          description: "Motivo ausente o vacío (`VAL-001`, `VAL-002`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: "Sin `roles:delete`, o el rol está asignado al propio actor\
+            \ (`RN-SEG-011`)"
+        "404":
+          description: El rol no existe o ya está eliminado (`EX-006`)
+        "409":
+          description: "Rol de sistema (`RN-SEG-012`), rol raíz (`RN-SEG-007`), o\
+            \ el rol tiene hijos o personas asignadas (`RN-SEG-008`)"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/memberships:
+    get:
+      tags:
+      - Membresías
+      summary: Consultar la cadena de membresías
+      description: |
+        Devuelve la cadena completa, de la superior al extremo inferior, sin paginar.
+
+        `level` es la distancia hasta la cima: `1` es la superior. El orden de la
+        colección lo refleja.
+
+        No se admite paginación ni ordenamiento: el orden **es** la información.
+        Los parámetros de paginación se ignoran y devuelven la cadena entera.
+      operationId: consultar
+      parameters:
+      - name: peticion
+        in: query
+        required: true
+        schema:
+          $ref: "#/components/schemas/ListMembershipsRequest"
+      responses:
+        "200":
+          description: Cadena devuelta. Puede venir vacía si aún no hay membresías.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MembershipChainResponse"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `memberships:read` (`AUTH-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+    post:
+      tags:
+      - Membresías
+      summary: Registrar una membresía
+      description: |
+        Inserta una membresía en la cadena, por encima de la hija indicada.
+
+        Si no se indica hija, la membresía queda en el extremo inferior y no se
+        reordena nada. Si se indica, la nueva ocupa su nivel, hereda su superior
+        y todo lo que estaba en ese nivel o por debajo baja uno.
+
+        El nivel y la superior **no se envían**: los calcula el sistema. Enviar
+        `level` o `parentMembershipId` devuelve `400`.
+      operationId: registrar_2
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterMembershipRequest"
+        required: true
+      responses:
+        "201":
+          description: "Membresía registrada, con la posición que ocupó."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MembershipResponse"
+        "400":
+          description: "Formato u obligatoriedad incumplidos, o campo no admitido\
+            \ en el cuerpo"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `memberships:create` (`AUTH-002`)
+        "409":
+          description: "Código o nombre ya en uso (`EX-001`), o la cadena cambió durante\
+            \ la operación (`EX-003`) y debe reintentarse"
+        "422":
+          description: La membresía hija indicada no existe (`EX-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/countries:
+    get:
+      tags:
+      - Países
+      summary: Consultar el catálogo de países
+      description: |
+        Devuelve el catálogo completo, sin paginar, **ordenado alfabéticamente
+        por nombre** según la intercalación del español — no por orden de bytes.
+
+        La búsqueda actúa sobre código y nombre, ignorando mayúsculas y acentos.
+        Sin coincidencias devuelve una colección vacía, no un error.
+
+        Los países inactivos no aparecen salvo que se pidan, y entonces se
+        **añaden** a los activos. La búsqueda y el estado son independientes.
+      operationId: consultar_1
+      parameters:
+      - name: peticion
+        in: query
+        required: true
+        schema:
+          $ref: "#/components/schemas/ListCountriesRequest"
+      responses:
+        "200":
+          description: Catálogo devuelto. Puede venir vacío.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CountryCatalogResponse"
+        "400":
+          description: El parámetro de inclusión no es booleano
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin el permiso de lectura de países (`AUTH-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+    post:
+      tags:
+      - Países
+      summary: Registrar un país
+      description: |
+        Registra un país en el catálogo. Queda **activo** siempre: el estado no
+        se envía y enviarlo devuelve `400`.
+
+        El código se normaliza a mayúsculas y se recorta, porque lo fija
+        ISO 3166-1 y no lo inventa nadie: `co`, ` CO` y `CO` son el mismo país.
+
+        El nombre admite acentos y caracteres no latinos sin transformación
+        alguna, pero **no puede coincidir** con otro ya registrado ignorando
+        mayúsculas y acentos: el catálogo no se edita, y el duplicado sería
+        permanente.
+      operationId: registrar_3
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RegisterCountryRequest"
+        required: true
+      responses:
+        "201":
+          description: "País registrado, con su código ya normalizado."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CountryResponse"
+        "400":
+          description: "Código o nombre inválidos, o campo no admitido en el cuerpo"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin el permiso de creación de países (`AUTH-002`)
+        "409":
+          description: Código o nombre ya presentes en el catálogo (`EX-001`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/auth/refresh:
+    post:
+      tags:
+      - Sesión
+      summary: Renovar la sesión
+      description: |
+        Rota el refresh token y entrega credenciales nuevas.
+
+        **La rotación es la defensa:** el token entregado deja de servir, de
+        modo que presentarlo de nuevo significa que existe una copia. En ese
+        caso se revoca la **familia entera** de la sesión y se emite la alarma.
+
+        Las cinco condiciones de rechazo devuelven la **misma** respuesta: el
+        cliente no debe poder deducir si el token fue robado, si expiró o si la
+        cuenta fue desactivada.
+      operationId: refresh
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RefreshRequest"
+        required: true
+      responses:
+        "200":
+          description: Credenciales renovadas.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/SessionResponse"
+        "400":
+          description: Refresh token ausente
+        "401":
+          description: "La sesión no es válida — cinco causas posibles, una sola respuesta"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+      security: []
+  /api/v1/auth/password:
+    post:
+      tags:
+      - Sesión
+      summary: Cambiar la propia contraseña
+      description: |
+        Sustituye la contraseña de **quien porta el token**.
+
+        **No lleva identificador de usuario**, y esa ausencia es la
+        implementación de la regla: no hay campo por el que dirigir la
+        operación a un tercero. Restablecer la contraseña de otra persona es
+        otra operación, con su propio permiso.
+
+        La contraseña actual se comprueba **la última**, después del formato, de
+        que la nueva sea distinta y de la política. Es el único paso que consume
+        el contador de intentos: ponerlo antes haría que cinco peticiones
+        descuidadas de un cliente propio bloquearan la cuenta de su titular.
+
+        La contraseña actual incorrecta devuelve `422` y **no `401`**: un `401`
+        le diría al cliente que su sesión ya no vale y lo mandaría a iniciar
+        sesión, cuando lo único que ocurrió es que escribió mal su contraseña.
+
+        **Aquí sí se dice qué falló**, al revés que al iniciar sesión: quien
+        hace esta petición ya está autenticado y no se le revela nada que no
+        supiera.
+
+        Al cambiarla, **todas las sesiones se revocan**, incluida la que ejecutó
+        el cambio.
+      operationId: cambiarContrasena
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangePasswordRequest"
+        required: true
+      responses:
+        "204":
+          description: Contraseña sustituida.
+        "400":
+          description: "Falta alguna de las dos (`VAL-001`, `VAL-002`), la nueva no\
+            \ cumple la política (`VAL-004`) o es igual a la actual (`VAL-005`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "422":
+          description: La contraseña actual no es correcta (`VAL-003`). Consume un
+            intento
+        "423":
+          description: La cuenta quedó bloqueada al alcanzar el umbral de fallos
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+      security:
+      - bearerAuth: []
+  /api/v1/auth/logout:
+    post:
+      tags:
+      - Sesión
+      summary: Cerrar sesión
+      description: |
+        Revoca el refresh token de la sesión, o **todos** los de la persona si
+        se pide.
+
+        Responde `204` para **cualquier** token sintácticamente válido, exista o
+        no, esté vigente o revocado. Distinguirlos permitiría comprobar con dos
+        peticiones si una cadena de texto es un refresh token del sistema, y el
+        resultado prometido —que ese token no sirva— se cumple igual.
+      operationId: logout
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LogoutRequest"
+        required: true
+      responses:
+        "204":
+          description: Sesión cerrada.
+        "400":
+          description: Refresh token ausente o con formato imposible
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+      security: []
+  /api/v1/auth/login:
+    post:
+      tags:
+      - Sesión
+      summary: Iniciar sesión
+      description: |
+        Autentica con **nombre de usuario o correo** —el mismo campo para los
+        dos— y entrega las credenciales de sesión.
+
+        La cuenta bloqueada recibe `423` y un mensaje que la identifica como
+        tal: es una excepción consciente al mensaje genérico, porque quien
+        provocó el bloqueo ya sabe que la cuenta existe.
+
+        Si la contraseña la fijó otra persona, la respuesta autentica **y
+        advierte** con `mustChangePassword`: hace falta una sesión para poder
+        cambiarla.
+      operationId: login
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LoginRequest"
+        required: true
+      responses:
+        "200":
+          description: Credenciales de sesión.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/SessionResponse"
+        "400":
+          description: Identificador o contraseña ausentes
+        "401":
+          description: "Credenciales inválidas, cuenta inexistente, inactiva o eliminada\
+            \ — los cuatro casos comparten cuerpo y mensaje, sin una sola diferencia\
+            \ observable"
+        "423":
+          description: Cuenta bloqueada
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+      security: []
+  /api/v1/users/{id}:
+    get:
+      tags:
+      - Usuarios
+      summary: Consultar el detalle de una persona
+      description: |
+        Sus roles **con el estado de cada uno**, sus permisos efectivos, su
+        membresía y el contexto de su acceso.
+
+        Las dos primeras juntas son lo único que explica por qué una persona
+        **con roles** no puede hacer nada: porque todos están inactivos y la
+        lista de permisos llega vacía.
+
+        Los permisos efectivos salen del **mismo componente que autoriza**, de
+        modo que esta respuesta no puede contradecir a lo que el sistema hará
+        con la siguiente petición de esa persona.
+
+        `lockedUntil` nulo significa dos cosas distintas y eso es información:
+        la cuenta no está bloqueada, o lo está **por decisión de un actor** y
+        por tanto sin expiración. El estado desambigua.
+
+        **No devuelve intentos fallidos** —diría cuántos le quedan a una cuenta
+        antes de bloquearse—, **ni dato alguno de la credencial**, **ni el
+        superior comercial**, que tiene su propio endpoint.
+
+        Una persona eliminada devuelve el **mismo** `404` que una inexistente,
+        sin ninguna pista de que existió.
+      operationId: detalle
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: La persona.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserDetailResponse"
+        "400":
+          description: El identificador no es un UUID en forma canónica (`VAL-001`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:read` (`AUTH-002`)
+        "404":
+          description: "No existe, o está eliminada (`EX-001`)"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+    patch:
+      tags:
+      - Usuarios
+      summary: Editar los datos de una persona
+      description: |
+        Modifica el nombre, los apellidos y el correo. `PATCH` y no `PUT`:
+        `PUT` obligaría a enviar el recurso completo —incluidos el nombre de
+        usuario, el estado y los roles, que esta operación **no** puede
+        modificar— y habría que decidir qué hacer si llegaran con otros valores.
+
+        **Los tres campos son opcionales y ninguno admite vaciarse.** El campo
+        ausente no se toca; el campo con nulo explícito o en blanco devuelve
+        `400`. Es la diferencia con la edición de un rol, donde el nulo sí era
+        una orden: aquí las columnas son `NOT NULL` y aceptarlo produciría un
+        `500` en lugar del `400` que corresponde.
+
+        **El nombre de usuario no se puede cambiar**, y enviarlo devuelve `400`
+        por propiedad desconocida en lugar de ignorarse en silencio. Lo mismo
+        con el estado, los roles, la membresía y la contraseña: cada uno tiene
+        su operación.
+
+        El correo se normaliza —recorte y minúsculas— **antes** de compararse,
+        de modo que reenviar el propio en mayúsculas es un cambio sin efecto y
+        no un conflicto consigo mismo.
+
+        **El actor sí puede editarse a sí mismo**: corregir el propio apellido
+        no concede ningún privilegio.
+      operationId: editar
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateUserRequest"
+        required: true
+      responses:
+        "200":
+          description: "La persona, con los datos actualizados."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserResponse"
+        "400":
+          description: "Ningún campo informado (`VAL-001`), campo vaciado (`VAL-002`),\
+            \ correo inválido (`VAL-003`), longitud excedida (`VAL-005`) o campo desconocido"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:update` (`AUTH-002`)
+        "404":
+          description: "No existe, o está eliminada (`EX-002`)"
+        "409":
+          description: "El correo ya está en uso (`RN-SP-016`). **El mensaje no dice\
+            \ de quién es**: puede ser de alguien eliminado, y decirlo revelaría una\
+            \ cuenta"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/{id}/supervisor:
+    patch:
+      tags:
+      - Usuarios
+      summary: Establecer o cambiar el superior comercial
+      description: |
+        `PATCH` sobre el subrecurso y no `PUT`: el cuerpo no representa el
+        estado completo —falta el periodo, que lo fija el sistema— y `PUT`
+        invitaría a pensar que se puede enviar.
+
+        **No admite fecha de inicio.** La asignación rige desde que se ejecuta,
+        siempre. Declararla obligaría a especificar solapamientos, huecos entre
+        tramos y correcciones retroactivas sobre periodos ya liquidados.
+
+        **No admite retirar el superior.** El estado «vendedor sin superior» no
+        existe: la única salida es dejar de portar rol comercial retirándolo.
+
+        Cada cambio **cierra** el tramo vigente con su fecha y **abre** otro:
+        nunca se sobrescribe el superior de una fila. La respuesta devuelve el
+        **anterior con su fecha de cierre**, que es lo que permite confirmar de
+        un vistazo que se cerró el tramo que se creía cerrar.
+
+        **El equipo se mueve con el reasignado**: sus subordinados conservan su
+        superior y solo cambia de quién depende la rama.
+
+        Repetir la operación con el mismo superior no cierra ni abre nada y no
+        deja auditoría — pero el motivo se exige igual, antes de saberlo.
+      operationId: asignarSuperior
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AssignSupervisorRequest"
+        required: true
+      responses:
+        "200":
+          description: "La estructura, con el superior nuevo y el anterior."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CommercialStructureResponse"
+        "400":
+          description: "Identificador malformado, o motivo ausente o vacío (`VAL-001`,\
+            \ `VAL-008`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:assign-supervisor` (`AUTH-002`)
+        "404":
+          description: Alguna de las dos personas no existe o está eliminada (`VAL-002`)
+        "409":
+          description: "El actor es el propio subordinado (`RN-SP-017`), el subordinado\
+            \ no pertenece a la fuerza comercial (`VAL-003`) o es la cúspide (`VAL-004`),\
+            \ el superior no porta el rol que exige el orden de mando (`RN-SP-020`)\
+            \ —el mensaje dice cuál—, no está activo (`VAL-006`), o sería su propio\
+            \ superior (`VAL-007`)"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/{id}/status:
+    patch:
+      tags:
+      - Usuarios
+      summary: Retirar o devolver el acceso de una persona
+      description: |
+        Subrecurso propio y no un campo de la edición: el estado tiene reglas de
+        rechazo que la edición no tiene y exige un motivo que la edición no
+        admite.
+
+        **Se envía el estado destino y no una acción**, lo que hace la operación
+        idempotente por construcción. Pedir el estado que ya se tiene no cambia
+        nada y no deja evento.
+
+        **Salvo en un caso, y es el que da sentido al requerimiento:** pasar de
+        bloqueo **automático** a bloqueo **manual** sí es un cambio aunque el
+        estado sea el mismo — `lockedUntil` pasa de informado a nulo, y con ello
+        el bloqueo deja de levantarse solo.
+
+        **El motivo es condicional en los dos sentidos:** obligatorio al retirar
+        el acceso, **rechazado** al devolverlo.
+
+        **`PENDIENTE` no se admite**, aunque el esquema lo acepte: ningún
+        requerimiento lo produce y sería el único camino hacia un estado del que
+        nadie sabe salir.
+
+        **Reactivar nunca falla por regla.** Devolver el acceso no puede dejar a
+        nadie sin administración ni a ningún equipo huérfano.
+
+        Retirar el acceso **revoca todas las sesiones** de la persona.
+      operationId: cambiarEstado
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeUserStatusRequest"
+        required: true
+      responses:
+        "200":
+          description: El estado resultante. `lockedUntil` nulo con BLOQUEADO significa
+            manual.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/UserStatusResponse"
+        "400":
+          description: "Estado ausente, fuera del dominio o `PENDIENTE` (`VAL-001`);\
+            \ motivo ausente al retirar (`VAL-005`) o presente al devolver (`VAL-006`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: "Autenticado sin `users:update` (`AUTH-002`), o es la cuenta\
+            \ del propio actor (`RN-SP-017`) — dos casos distintos con `error_code`\
+            \ distinto"
+        "404":
+          description: "No existe, o está eliminada (`EX-005`)"
+        "409":
+          description: "Es el último superadministrador activo (`RN-SP-001`), o tiene\
+            \ personas a cargo (`RN-SP-022`) — este último dice **cuántas**, nunca\
+            \ quiénes"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/roles/{id}:
+    get:
+      tags:
+      - Roles
+      summary: Consultar el detalle de un rol
+      description: |
+        Devuelve el alcance exacto de un rol: **la lista completa de los
+        permisos que declara**, su rol padre, **cuántos** roles cuelgan de él y
+        **cuántas** personas lo tienen asignado.
+
+        **Los permisos son los declarados, sin recorrer la cadena de
+        ancestros** (`RN-SEG-004`): el modelo no usa herencia, y esa decisión
+        existe precisamente para que esta pregunta se responda leyendo una sola
+        lista. Van completos y sin paginar, ordenados por código.
+
+        **`childRoleCount` es un número, nunca una lista**: el listado de hijos
+        se obtiene con `GET /api/v1/roles?parentRoleId={id}`, que ya está
+        paginado. Así el tamaño de la respuesta no depende de cuántos hijos
+        tenga el rol.
+
+        **`assignedUserCount` cuenta personas distintas**, en cualquier estado
+        —incluidas las inactivas y las bloqueadas— y **excluyendo las
+        eliminadas**: alguien bloqueado sigue portando el rol, y su existencia
+        es lo que impide borrarlo. Cero es un dato, no una ausencia. **No exige
+        `users:read`**: es un agregado sin identidad, y quien quiera saber
+        quiénes son usa `GET /api/v1/users?roleId={id}`.
+
+        Un rol **eliminado devuelve el mismo `404`** que uno inexistente, sin
+        ninguna pista de que existió.
+      operationId: detalle_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Detalle del rol.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleDetailResponse"
+        "400":
+          description: El identificador no es un UUID en forma canónica (`VAL-001`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `roles:read` (`AUTH-002`)
+        "404":
+          description: "No existe el rol, o está eliminado lógicamente (`EX-001`)"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+    patch:
+      tags:
+      - Roles
+      summary: Editar un rol
+      description: |
+        Modifica el **nombre** y la **descripción**. Nada más: el código es
+        estable por diseño —cambiarlo rompería cualquier referencia externa— y
+        la clasificación es **inmutable**, porque determina si el rol puede
+        llevar membresía y cambiarla dejaría membresías colgando de un rol que
+        ya no es consumidor. Los permisos, el estado y el rol padre tienen cada
+        uno su operación.
+
+        Al menos uno de los dos campos debe venir informado. `description`
+        admite `null` explícito —borrarla es una orden legítima—; `name` no,
+        porque un rol sin nombre no existe.
+
+        **Reenviar los valores actuales no es un error ni registra evento**: si
+        nada cambió, no hay nada que auditar.
+
+        **Un rol de sistema devuelve `409` y un rol que usted tiene asignado,
+        `403`**. Lo segundo impide ampliar el alcance del rol con el que se
+        está entrando; alcanza solo a los roles asignados **directamente**, de
+        modo que un ancestro del propio sí puede editarse.
+      operationId: editar_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/UpdateRoleRequest"
+        required: true
+      responses:
+        "200":
+          description: Rol actualizado.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "400":
+          description: "Ningún campo informado (`VAL-001`), nombre vacío (`VAL-002`)\
+            \ o longitud excedida (`VAL-004`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "403":
+          description: "Sin `roles:update` (`AUTH-002`), o el rol está asignado al\
+            \ propio actor (`RN-SEG-011`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "404":
+          description: El rol no existe o está eliminado (`EX-004`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "409":
+          description: Rol de sistema (`RN-SEG-012`) o nombre ya en uso (`RN-SEG-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+  /api/v1/roles/{id}/status:
+    patch:
+      tags:
+      - Roles
+      summary: Activar o desactivar un rol
+      description: |
+        **Desactivar no es retirar.** Las asignaciones a personas se conservan
+        intactas; lo que cambia es que el rol **deja de conceder permisos de
+        inmediato**, sin esperar a que ningún token expire.
+
+        Se pide el **estado destino** —`ACTIVO` o `INACTIVO`— y no una acción,
+        de modo que repetir la petición deja el mismo resultado y no registra
+        evento.
+
+        **El rol raíz no admite esta operación**, aparte de la prohibición
+        general sobre los roles de sistema: un rol raíz inactivo no concede
+        nada, y eso dejaría al sistema sin su última vía de administración.
+
+        El cuerpo no admite motivo: el Art. V.13 lo exige solo en las
+        eliminaciones.
+      operationId: cambiarEstado_1
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeRoleStatusRequest"
+        required: true
+      responses:
+        "200":
+          description: Rol con su estado actualizado.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "400":
+          description: Estado ausente o fuera del dominio (`VAL-001`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "403":
+          description: "Sin `roles:update`, o el rol está asignado al propio actor\
+            \ (`RN-SEG-011`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "404":
+          description: El rol no existe o está eliminado (`EX-003`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "409":
+          description: Rol de sistema (`RN-SEG-012`) o rol raíz (`RN-SEG-007`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+  /api/v1/roles/{id}/parent:
+    patch:
+      tags:
+      - Roles
+      summary: Cambiar el rol padre
+      description: |
+        Reubica el rol bajo otro padre y **revalida la contención contra el
+        nuevo** (`RN-SEG-013`): si el rol declara permisos que el nuevo padre
+        no posee, la operación se rechaza **entera** enumerándolos, para que
+        usted decida cuáles retirar. **Nunca se recorta nada en silencio.**
+
+        **Los hijos acompañan al rol** y no hay que revisarlos: si este cabe en
+        el nuevo padre, ellos caben en este por transitividad.
+
+        El nuevo padre debe existir y estar **activo**, y no puede ser el
+        propio rol ni uno de sus descendientes —eso formaría un ciclo—. Su
+        clasificación es indiferente: un rol comercial puede colgar de uno
+        funcionario, porque el padre acota privilegios, no clasifica.
+
+        **El rol raíz no admite padre** y ningún rol puede quedarse sin él:
+        `RN-SEG-007` exige exactamente una cima.
+      operationId: cambiarPadre
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeRoleParentRequest"
+        required: true
+      responses:
+        "200":
+          description: Rol con su nuevo rol padre.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "400":
+          description: Rol padre ausente o mal formado (`VAL-001`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "403":
+          description: "Sin `roles:update`, o el rol está asignado al propio actor\
+            \ (`RN-SEG-011`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "404":
+          description: El rol no existe o está eliminado (`EX-006`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "409":
+          description: "Rol de sistema (`RN-SEG-012`), rol raíz (`RN-SEG-007`), ciclo\
+            \ en la jerarquía (`RN-SEG-006`) o permisos que el nuevo padre no concede\
+            \ (`RN-SEG-013`)"
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "422":
+          description: El rol padre indicado no existe o no está activo (`EX-004`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/RoleResponse"
+  /api/v1/currencies/{id}/status:
+    patch:
+      tags:
+      - Monedas
+      summary: Activar o desactivar una moneda
+      description: |
+        Cambia el estado de una moneda del catálogo. Es lo **único** que la API
+        puede modificar de una moneda.
+
+        Se envía el estado destino, no una acción: pedir dos veces lo mismo deja
+        el mismo estado y **no** registra un segundo evento.
+
+        La moneda por defecto **no puede desactivarse**: los importes del sistema
+        quedarían sin referencia válida. Cambiar cuál es la moneda por defecto es
+        una operación de migración, no de API.
+
+        El cuerpo no admite ningún otro campo ni motivo alguno.
+      operationId: cambiarEstado_2
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeCurrencyStatusRequest"
+        required: true
+      responses:
+        "200":
+          description: "Estado aplicado. Devuelve la moneda completa, con su definició\
+            n sin cambios."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CurrencyResponse"
+        "400":
+          description: "Identificador o cuerpo inválidos, o campo no admitido (`VAL-001`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin el permiso de modificación de monedas (`AUTH-002`)
+        "404":
+          description: No existe moneda con ese identificador (`EX-002`)
+        "409":
+          description: Se intenta desactivar la moneda por defecto (`RN-SP-010`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/countries/{id}/status:
+    patch:
+      tags:
+      - Países
+      summary: Activar o desactivar un país
+      description: |
+        Cambia el estado de un país. Es lo **único** que la API puede modificar
+        de un país.
+
+        Se envía el estado destino, no una acción: pedir dos veces lo mismo deja
+        el mismo estado y **no** registra un segundo evento.
+
+        **Desactivar no es corregir**: el código y el nombre permanecen, y los
+        datos que ya los referencian siguen resolviéndolos. Evita que el error se
+        propague desde ese momento, no lo repara.
+
+        El cuerpo no admite ningún otro campo ni motivo alguno.
+      operationId: cambiarEstado_3
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeCountryStatusRequest"
+        required: true
+      responses:
+        "200":
+          description: Estado aplicado. Devuelve el país tal como quedó.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CountryResponse"
+        "400":
+          description: "Identificador o cuerpo inválidos, o campo no admitido (`VAL-001`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin el permiso de modificación de países (`AUTH-002`)
+        "404":
+          description: No existe país con ese identificador (`EX-001`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/{id}/team:
+    get:
+      tags:
+      - Usuarios
+      summary: Consultar el superior y el equipo a cargo
+      description: |
+        Devuelve el superior inmediato y el **equipo directo** de la persona,
+        paginado.
+
+        **Un solo nivel, nunca el árbol descendente**, y **sin conteo
+        indirecto**: `totalElements` cuenta a quienes reportan directamente.
+        Devolver la rama completa publicaría de una vez la estructura de la
+        empresa por un permiso de lectura de usuarios.
+
+        **Sin filtros.** El listado general de usuarios ya filtra; replicar esa
+        semántica sobre un subconjunto que cabe en una o dos páginas obligaría
+        a mantener dos filtrados sincronizados sin responder nada nuevo.
+
+        **Sin historial de superiores.**
+
+        `supervisor` va **ausente**, no en nulo, cuando la persona es la cúspide
+        comercial: es lo que distingue «no depende de nadie» de «no se pudo
+        resolver».
+
+        Quien no pertenece a la fuerza comercial recibe `200` con la estructura
+        vacía, no `404` ni `409`.
+
+        **El alcance es global** mientras la decisión D-22 siga abierta: quien
+        posea el permiso ve el equipo de cualquiera, no solo el suyo.
+      operationId: equipo
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      responses:
+        "200":
+          description: "La estructura, con el equipo paginado."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CommercialStructureResponse"
+        "400":
+          description: Identificador malformado o paginación fuera de límites (`VAL-003`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `users:read` (`AUTH-002`)
+        "404":
+          description: La persona no existe o está eliminada (`VAL-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/users/me:
+    get:
+      tags:
+      - Usuarios
+      summary: Consultar el propio perfil
+      description: |
+        Devuelve el perfil de **quien porta el token**, con sus **permisos
+        efectivos**.
+
+        `me` es un **literal**, no un identificador: no se admite pedir el
+        propio detalle por la ruta con identificador, que es otra operación y
+        exige permiso de lectura de usuarios.
+
+        **Sin parámetros de ningún tipo** — ni de ruta, ni de consulta, ni de
+        cuerpo.
+
+        Los permisos salen del **mismo componente que autoriza**, de modo que lo
+        que esta pantalla dice que la persona puede hacer es exactamente lo que
+        el sistema le dejará hacer. Es lo que permite a una interfaz decidir qué
+        mostrar sin duplicar en el navegador una regla que vive en el servidor.
+
+        **No exige permiso alguno**, solo estar autenticado: no hay recurso
+        ajeno que proteger.
+
+        Devuelve **solo el superior comercial, nunca el equipo**: a quién
+        reporta uno es un dato del actor; quiénes dependen de uno es un conjunto
+        de terceros.
+
+        `lastLoginAt` es un dato **informativo de la sesión en curso**, no una
+        señal de intrusión: el inicio de sesión sobrescribe ese valor al entrar.
+      operationId: miPerfil
+      responses:
+        "200":
+          description: El perfil.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/OwnProfileResponse"
+        "401":
+          description: "Sin credencial válida, o la cuenta fue eliminada tras emitirse\
+            \ el token (`AUTH-001`) — lo que dejó de valer es la sesión, no la ruta,\
+            \ y por eso no es `404`"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/permissions:
+    get:
+      tags:
+      - Permisos
+      summary: Consultar el catálogo de permisos
+      description: |
+        Devuelve el catálogo completo, sin paginar, ordenado por recurso y acción.
+
+        Los tres filtros son opcionales y ninguno se valida: un valor que no
+        corresponda a ningún permiso produce una colección vacía, no un error.
+        Los parámetros de paginación no se admiten y se ignoran.
+      operationId: list
+      parameters:
+      - name: request
+        in: query
+        description: Filtro por recurso. Coincidencia exacta.
+        required: true
+        schema:
+          $ref: "#/components/schemas/ListPermissionsRequest"
+      responses:
+        "200":
+          description: Catálogo devuelto. La colección puede venir vacía.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionCatalogResponse"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionCatalogResponse"
+        "403":
+          description: Autenticado sin el permiso `permissions:read` (`AUTH-002`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionCatalogResponse"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionCatalogResponse"
+  /api/v1/permissions/{id}:
+    get:
+      tags:
+      - Permisos
+      summary: Consultar el detalle de un permiso
+      description: |
+        Devuelve qué habilita un permiso concreto: código, recurso, acción,
+        nombre y descripción. Es la consulta de apoyo a la asignación de
+        permisos a un rol, y se llega a ella desde el catálogo.
+
+        **Se accede solo por identificador, nunca por código**: admitir dos
+        formas de direccionar el mismo recurso obliga a distinguir en cada
+        petición cuál llegó. El código es la vía para *encontrar* el permiso, y
+        para eso está el filtro del catálogo.
+
+        **No devuelve los roles que lo declaran** —es el recorrido inverso y
+        corresponde a una consulta propia— ni marcas temporales: en una tabla
+        que solo cambia por migración, esas fechas dicen cuándo se desplegó una
+        migración y no cuándo ocurrió algo de negocio.
+
+        `description` puede venir vacía, y entonces se devuelve como `null`,
+        nunca omitida.
+      operationId: detail
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Detalle del permiso.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionResponse"
+        "400":
+          description: El identificador no es un UUID en forma canónica (`VAL-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionResponse"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionResponse"
+        "403":
+          description: Autenticado sin el permiso `permissions:read` (`AUTH-002`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionResponse"
+        "404":
+          description: No existe un permiso con ese identificador (`EX-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionResponse"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PermissionResponse"
+  /api/v1/memberships/{id}:
+    get:
+      tags:
+      - Membresías
+      summary: Consultar el detalle de una membresía
+      description: |
+        Devuelve la membresía con sus dos vecinos inmediatos, expandidos.
+
+        Los vecinos llegan solo hasta el primer grado y no traen los suyos: la
+        cadena entera se obtiene con el listado.
+      operationId: consultarDetalle
+      parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Detalle devuelto.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/MembershipDetailResponse"
+        "400":
+          description: El identificador no es un UUID (`VAL-001`)
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin `memberships:read` (`AUTH-002`)
+        "404":
+          description: No existe membresía con ese identificador (`EX-001`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/currencies:
+    get:
+      tags:
+      - Monedas
+      summary: Consultar el catálogo de monedas
+      description: |
+        Devuelve el catálogo completo, sin paginar, ordenado por código.
+
+        `decimalPlaces` es el campo del que depende el redondeo de todo cálculo
+        financiero: cero es un valor legítimo y el campo nunca es nulo.
+
+        Las monedas inactivas no aparecen salvo que se pidan con
+        `includeInactive=true`, que **añade** a las activas en lugar de
+        sustituirlas.
+      operationId: consultar_2
+      parameters:
+      - name: peticion
+        in: query
+        required: true
+        schema:
+          $ref: "#/components/schemas/ListCurrenciesRequest"
+      responses:
+        "200":
+          description: "Catálogo devuelto. Siempre es una colección, aunque tenga\
+            \ un solo elemento."
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/CurrencyCatalogResponse"
+        "400":
+          description: El parámetro de inclusión no es booleano
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+        "403":
+          description: Autenticado sin el permiso de lectura de monedas (`AUTH-002`)
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+  /api/v1/audit/security:
+    get:
+      tags:
+      - Auditoría
+      summary: Consultar la auditoría de seguridad
+      description: |
+        Entradas, bloqueos, cambios de privilegio y denegaciones de
+        autorización, del más reciente al más antiguo.
+
+        **Esta consulta se registra a sí misma.** Cada llamada deja un evento
+        de seguridad con quién la hizo, cuándo y **con qué filtros**: en este
+        registro, el acto de mirar es en sí mismo información de seguridad — y
+        quién revisó los accesos de una cuenta ajena es exactamente la clase de
+        hecho que conviene conservar. Es la diferencia con los otros tres, que
+        se conforman con el registro de peticiones.
+
+        **`targetUserId` es el filtro de la investigación de una cuenta**: qué
+        le pasó a esta persona en estas fechas. Los **intentos de acceso
+        fallidos no llevan usuario afectado** y por tanto no aparecen ahí: la
+        presencia de ese campo delataría que la cuenta existe. Se localizan por
+        tipo de evento y rango, leyendo el identificador intentado en `detail`.
+
+        **`detail` no contiene credenciales en ninguna forma** —ni contraseñas,
+        ni resúmenes, ni tokens—, y eso se garantiza al escribir.
+      operationId: seguridad
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: eventType
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: severity
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: outcome
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: actorId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: targetUserId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: ipAddress
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      responses:
+        "200":
+          description: Página de eventos de seguridad.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponse"
+        "400":
+          description: "Rango incoherente (`VAL-001`), paginación fuera de límites\
+            \ (`VAL-002`) o tipo de evento, severidad o resultado fuera de su dominio\
+            \ (`VAL-003`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseSecurityAuditItem"
+        "403":
+          description: Autenticado sin `audit:read-security` (`AUTH-002`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseSecurityAuditItem"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseSecurityAuditItem"
+  /api/v1/audit/errors:
+    get:
+      tags:
+      - Auditoría
+      summary: Consultar la auditoría de error
+      description: |
+        Fallos no controlados y rechazos por regla de negocio, del más reciente
+        al más antiguo.
+
+        **El filtro para el que existe esta consulta es `correlationId`**:
+        alguien reporta un error citando el identificador que la respuesta le
+        devolvió, y con él se llega al fallo concreto y a la traza técnica que
+        lo acompaña.
+
+        **Qué NO aparece aquí, y es la frontera que más importa:** la denegación
+        de autorización (`403`) vive en la auditoría de **seguridad**, porque no
+        es un fallo del sistema sino el sistema funcionando. Tampoco la
+        validación de formato, el `401` ni el `404` — esos los cubre el registro
+        de peticiones.
+
+        `message` viene **ya saneado** desde que se escribió: sin trazas, sin
+        SQL, sin rutas y sin versiones.
+      operationId: errores
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: errorType
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: severity
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: errorCode
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: resource
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: actorId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: correlationId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Página de fallos registrados.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponse"
+        "400":
+          description: "Rango incoherente (`VAL-001`), paginación fuera de límites\
+            \ (`VAL-002`) o tipo o severidad fuera de su dominio (`VAL-003`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseErrorAuditItem"
+        "403":
+          description: Autenticado sin `audit:read-errors` (`AUTH-002`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseErrorAuditItem"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseErrorAuditItem"
+  /api/v1/audit/deletions:
+    get:
+      tags:
+      - Auditoría
+      summary: Consultar la auditoría de eliminación
+      description: |
+        Qué se eliminó, quién lo eliminó y **por qué**, del más reciente al más
+        antiguo.
+
+        **`snapshot` es lo que hace útil a este registro**: el estado completo
+        del registro en el momento de borrarse. Sin él, la fila diría que un
+        identificador fue eliminado y nadie recordaría qué era.
+
+        **`reason` va vacío en las eliminaciones de asociación** —retirar un
+        permiso de un rol, por ejemplo—, y es correcto: lo que desaparece es una
+        asociación y no una entidad de negocio, de modo que no exige motivo.
+
+        El filtro `reason` **busca por texto** dentro del motivo, sin distinguir
+        acentos ni mayúsculas: es prosa que escribió una persona y nadie
+        recuerda cómo la redactó. Por lo mismo, buscar por motivo deja fuera las
+        eliminaciones de asociación, que no lo llevan.
+      operationId: eliminaciones
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: module
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: entity
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: entityId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: actorId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: deletionType
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: reason
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: correlationId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Página de eventos de eliminación.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponse"
+        "400":
+          description: "Rango incoherente (`VAL-001`), paginación fuera de límites\
+            \ (`VAL-002`) o tipo de eliminación fuera de su dominio (`VAL-003`)"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseDeletionAuditItem"
+        "403":
+          description: Autenticado sin `audit:read-deletions` (`AUTH-002`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseDeletionAuditItem"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseDeletionAuditItem"
+  /api/v1/audit/changes:
+    get:
+      tags:
+      - Auditoría
+      summary: Consultar la auditoría de cambios
+      description: |
+        Altas y ediciones de todo el sistema, **del más reciente al más
+        antiguo**. El orden no se puede cambiar: es parte del significado de un
+        registro cronológico.
+
+        **`changes` se devuelve tal como se escribió**, sin interpretar: en un
+        `CREATE` es el estado inicial del registro y en un `UPDATE` solo los
+        campos que cambiaron, cada uno con su `before` y su `after`.
+
+        **`correlationId` enlaza con la petición** que produjo el evento, y con
+        lo que esa misma petición dejó en los otros tres registros. Cuando son
+        nulos, `correlationId` e `ipAddress` lo son **a la vez**: significa que
+        el cambio no vino de la red —una migración, una tarea programada—, y
+        nunca que se olvidara registrarlo. `actorId` nulo se lee igual: lo hizo
+        el sistema.
+
+        **Ningún filtro es obligatorio**, ni siquiera el rango de fechas: la
+        consulta que más valor tiene es la línea de tiempo completa de un
+        registro. `from` y `to` son **instantes** con zona horaria, no fechas
+        sueltas, y el rango es **semiabierto** —incluye `from`, excluye `to`—
+        para que dos rangos consecutivos no devuelvan dos veces el evento de la
+        frontera.
+
+        **`entityId` y `actorId` no se validan contra nada**: la auditoría
+        conserva eventos de registros que ya no existen, que es su razón de ser.
+      operationId: cambios
+      parameters:
+      - name: page
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: size
+        in: query
+        required: false
+        schema:
+          type: integer
+          format: int32
+      - name: module
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: entity
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: entityId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: actorId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      - name: action
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: from
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: to
+        in: query
+        required: false
+        schema:
+          type: string
+          format: date-time
+      - name: correlationId
+        in: query
+        required: false
+        schema:
+          type: string
+          format: uuid
+      responses:
+        "200":
+          description: Página de eventos de cambio.
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponse"
+        "400":
+          description: "Rango de fechas incoherente (`VAL-001`), paginación fuera\
+            \ de límites (`VAL-002`) o filtro fuera de su dominio (`VAL-003`). Se\
+            \ devuelven **juntos**"
+        "401":
+          description: Token ausente o inválido (`AUTH-001`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseChangeAuditItem"
+        "403":
+          description: Autenticado sin `audit:read-changes` (`AUTH-002`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseChangeAuditItem"
+        "500":
+          description: Fallo no controlado (`ERR-500`)
+          content:
+            '*/*':
+              schema:
+                $ref: "#/components/schemas/PageResponseChangeAuditItem"
+components:
+  schemas:
+    AssignMembershipRequest:
+      type: object
+      properties:
+        membershipId:
+          type: string
+          format: uuid
+        endsAt:
+          type: string
+          format: date-time
+      required:
+      - membershipId
+    UserMembershipResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        level:
+          type: integer
+          format: int32
+        endsAt:
+          type: string
+          format: date-time
+    RegisterUserRequest:
+      type: object
+      properties:
+        username:
+          type: string
+          minLength: 1
+        email:
+          type: string
+          minLength: 1
+        firstName:
+          type: string
+          maxLength: 100
+          minLength: 0
+        lastName:
+          type: string
+          maxLength: 100
+          minLength: 0
+        password:
+          type: string
+          minLength: 1
+        roleIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          maxItems: 100
+          minItems: 0
+        membershipId:
+          type: string
+          format: uuid
+        supervisorId:
+          type: string
+          format: uuid
+      required:
+      - email
+      - firstName
+      - lastName
+      - password
+      - roleIds
+      - username
+    MembershipRef:
+      type: object
+      properties:
+        code:
+          type: string
+        level:
+          type: integer
+          format: int32
+        endsAt:
+          type: string
+          format: date-time
+    RoleRef:
+      type: object
+      properties:
+        code:
+          type: string
+        name:
+          type: string
+        status:
+          type: string
+    SupervisorRef:
+      type: object
+      properties:
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        roleCode:
+          type: string
+    UserResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        status:
+          type: string
+        mustChangePassword:
+          type: boolean
+        roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleRef"
+        membership:
+          $ref: "#/components/schemas/MembershipRef"
+        supervisor:
+          $ref: "#/components/schemas/SupervisorRef"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    AssignRolesRequest:
+      type: object
+      properties:
+        roleIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          maxItems: 100
+          minItems: 0
+        membershipId:
+          type: string
+          format: uuid
+        membershipEndsAt:
+          type: string
+          format: date-time
+        supervisorId:
+          type: string
+          format: uuid
+      required:
+      - roleIds
+    RevokeRolesRequest:
+      type: object
+      properties:
+        roleIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          maxItems: 100
+          minItems: 0
+      required:
+      - roleIds
+    ResetPasswordRequest:
+      type: object
+      properties:
+        newPassword:
+          type: string
+    DeleteUserRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+    CreateRoleRequest:
+      type: object
+      properties:
+        code:
+          type: string
+          maxLength: 50
+          minLength: 0
+          pattern: "^[A-Z][A-Z0-9_]*$"
+        name:
+          type: string
+          maxLength: 100
+          minLength: 0
+        description:
+          type: string
+          maxLength: 500
+          minLength: 0
+        roleType:
+          type: string
+          enum:
+          - FUNCIONARIO
+          - VENDEDOR
+          - CONSUMIDOR
+        parentRoleId:
+          type: string
+          format: uuid
+        permissionIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+      required:
+      - code
+      - name
+      - parentRoleId
+      - roleType
+    PermissionResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        resource:
+          type: string
+        action:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+    RoleResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        roleType:
+          type: string
+        status:
+          type: string
+        isSystem:
+          type: boolean
+        parentRole:
+          $ref: "#/components/schemas/RoleSummaryResponse"
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PermissionResponse"
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    RoleSummaryResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+    RolePermissionsRequest:
+      type: object
+      properties:
+        permissionIds:
+          type: array
+          items:
+            type: string
+            format: uuid
+          maxItems: 100
+          minItems: 0
+          uniqueItems: true
+      required:
+      - permissionIds
+    DeleteRoleRequest:
+      type: object
+      properties:
+        reason:
+          type: string
+    RegisterMembershipRequest:
+      type: object
+      properties:
+        code:
+          type: string
+          maxLength: 50
+          minLength: 0
+          pattern: "^[A-Z][A-Z0-9_]*$"
+        name:
+          type: string
+          maxLength: 100
+          minLength: 0
+        description:
+          type: string
+          maxLength: 500
+          minLength: 0
+        childMembershipId:
+          type: string
+          format: uuid
+      required:
+      - code
+      - name
+    MembershipResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        level:
+          type: integer
+          format: int32
+        parentMembershipId:
+          type: string
+          format: uuid
+        childMembershipId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    RegisterCountryRequest:
+      type: object
+      properties:
+        code:
+          type: string
+          maxLength: 10
+          minLength: 0
+        name:
+          type: string
+          maxLength: 100
+          minLength: 0
+      required:
+      - code
+      - name
+    CountryResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        isActive:
+          type: boolean
+    RefreshRequest:
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          minLength: 1
+      required:
+      - refreshToken
+    SessionResponse:
+      type: object
+      properties:
+        accessToken:
+          type: string
+        refreshToken:
+          type: string
+        tokenType:
+          type: string
+        expiresIn:
+          type: integer
+          format: int64
+        mustChangePassword:
+          type: boolean
+    ChangePasswordRequest:
+      type: object
+      properties:
+        currentPassword:
+          type: string
+        newPassword:
+          type: string
+    LogoutRequest:
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          minLength: 1
+        allSessions:
+          type: boolean
+      required:
+      - refreshToken
+    LoginRequest:
+      type: object
+      properties:
+        identifier:
+          type: string
+          minLength: 1
+        password:
+          type: string
+          minLength: 1
+      required:
+      - identifier
+      - password
+    PatchableString: {}
+    UpdateUserRequest:
+      type: object
+      properties:
+        firstName:
+          $ref: "#/components/schemas/PatchableString"
+        lastName:
+          $ref: "#/components/schemas/PatchableString"
+        email:
+          $ref: "#/components/schemas/PatchableString"
+    AssignSupervisorRequest:
+      type: object
+      properties:
+        supervisorId:
+          type: string
+          format: uuid
+        reason:
+          type: string
+      required:
+      - supervisorId
+    CommercialStructureResponse:
+      type: object
+      properties:
+        user:
+          $ref: "#/components/schemas/Person"
+        supervisor:
+          $ref: "#/components/schemas/Person"
+        previousSupervisor:
+          $ref: "#/components/schemas/Person"
+        previousSupervisorEndedAt:
+          type: string
+          format: date-time
+        team:
+          $ref: "#/components/schemas/PageResponsePerson"
+    PageResponsePerson:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/Person"
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalIsExact:
+          type: boolean
+    Person:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        roleCode:
+          type: string
+        status:
+          type: string
+        since:
+          type: string
+          format: date-time
+    ChangeUserStatusRequest:
+      type: object
+      properties:
+        status:
+          type: string
+        reason:
+          type: string
+    UserStatusResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        status:
+          type: string
+        lockedUntil:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    UpdateRoleRequest:
+      type: object
+      properties:
+        name:
+          $ref: "#/components/schemas/PatchableString"
+        description:
+          $ref: "#/components/schemas/PatchableString"
+    ChangeRoleStatusRequest:
+      type: object
+      properties:
+        status:
+          type: string
+          minLength: 1
+      required:
+      - status
+    ChangeRoleParentRequest:
+      type: object
+      properties:
+        parentRoleId:
+          type: string
+          format: uuid
+      required:
+      - parentRoleId
+    ChangeCurrencyStatusRequest:
+      type: object
+      properties:
+        isActive:
+          type: boolean
+      required:
+      - isActive
+    CurrencyResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        symbol:
+          type: string
+        decimalPlaces:
+          type: integer
+          format: int32
+        isDefault:
+          type: boolean
+        isActive:
+          type: boolean
+    ChangeCountryStatusRequest:
+      type: object
+      properties:
+        isActive:
+          type: boolean
+      required:
+      - isActive
+    PageResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items: {}
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalIsExact:
+          type: boolean
+    UserDetailResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        username:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        status:
+          type: string
+        roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleRef"
+        effectivePermissions:
+          type: array
+          items:
+            type: string
+        membership:
+          $ref: "#/components/schemas/MembershipRef"
+        lastLoginAt:
+          type: string
+          format: date-time
+        lockedUntil:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    OwnProfileResponse:
+      type: object
+      properties:
+        username:
+          type: string
+        email:
+          type: string
+        firstName:
+          type: string
+        lastName:
+          type: string
+        status:
+          type: string
+        roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/RoleRef"
+        permissions:
+          type: array
+          items:
+            type: string
+        membership:
+          $ref: "#/components/schemas/MembershipRef"
+        lastLoginAt:
+          type: string
+          format: date-time
+        supervisor:
+          $ref: "#/components/schemas/SupervisorRef"
+        mustChangePassword:
+          type: boolean
+    RoleDetailResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        roleType:
+          type: string
+        status:
+          type: string
+        isSystem:
+          type: boolean
+        parentRole:
+          $ref: "#/components/schemas/RoleSummaryResponse"
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/PermissionResponse"
+        childRoleCount:
+          type: integer
+          format: int64
+        assignedUserCount:
+          type: integer
+          format: int64
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    ListPermissionsRequest:
+      type: object
+      properties:
+        resource:
+          type: string
+        action:
+          type: string
+        search:
+          type: string
+    PermissionCatalogResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/PermissionResponse"
+    ListMembershipsRequest:
+      type: object
+      properties:
+        search:
+          type: string
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        level:
+          type: integer
+          format: int32
+        parentMembershipId:
+          type: string
+          format: uuid
+        childMembershipId:
+          type: string
+          format: uuid
+    MembershipChainResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/Item"
+    MembershipDetailResponse:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        level:
+          type: integer
+          format: int32
+        parentMembership:
+          $ref: "#/components/schemas/Neighbor"
+        childMembership:
+          $ref: "#/components/schemas/Neighbor"
+    Neighbor:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        code:
+          type: string
+        name:
+          type: string
+        level:
+          type: integer
+          format: int32
+    ListCurrenciesRequest:
+      type: object
+      properties:
+        includeInactive:
+          type: boolean
+    CurrencyCatalogResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/CurrencyResponse"
+    ListCountriesRequest:
+      type: object
+      properties:
+        search:
+          type: string
+        includeInactive:
+          type: boolean
+    CountryCatalogResponse:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/CountryResponse"
+    JsonNode: {}
+    PageResponseSecurityAuditItem:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/SecurityAuditItem"
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalIsExact:
+          type: boolean
+    SecurityAuditItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        occurredAt:
+          type: string
+          format: date-time
+        actorId:
+          type: string
+          format: uuid
+        eventType:
+          type: string
+        severity:
+          type: string
+        outcome:
+          type: string
+        targetUserId:
+          type: string
+          format: uuid
+        detail:
+          $ref: "#/components/schemas/JsonNode"
+        correlationId:
+          type: string
+          format: uuid
+        ipAddress:
+          type: string
+        userAgent:
+          type: string
+    ErrorAuditItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        occurredAt:
+          type: string
+          format: date-time
+        actorId:
+          type: string
+          format: uuid
+        resource:
+          type: string
+        entityId:
+          type: string
+          format: uuid
+        operation:
+          type: string
+        errorCode:
+          type: string
+        errorType:
+          type: string
+        httpStatus:
+          type: integer
+          format: int32
+        severity:
+          type: string
+        message:
+          type: string
+        correlationId:
+          type: string
+          format: uuid
+        ipAddress:
+          type: string
+        userAgent:
+          type: string
+    PageResponseErrorAuditItem:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/ErrorAuditItem"
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalIsExact:
+          type: boolean
+    DeletionAuditItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        occurredAt:
+          type: string
+          format: date-time
+        actorId:
+          type: string
+          format: uuid
+        module:
+          type: string
+        entity:
+          type: string
+        entityId:
+          type: string
+          format: uuid
+        deletionType:
+          type: string
+        reason:
+          type: string
+        snapshot:
+          $ref: "#/components/schemas/JsonNode"
+        correlationId:
+          type: string
+          format: uuid
+        ipAddress:
+          type: string
+        userAgent:
+          type: string
+    PageResponseDeletionAuditItem:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/DeletionAuditItem"
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalIsExact:
+          type: boolean
+    ChangeAuditItem:
+      type: object
+      properties:
+        id:
+          type: string
+          format: uuid
+        occurredAt:
+          type: string
+          format: date-time
+        actorId:
+          type: string
+          format: uuid
+        module:
+          type: string
+        entity:
+          type: string
+        entityId:
+          type: string
+          format: uuid
+        action:
+          type: string
+        changes:
+          $ref: "#/components/schemas/JsonNode"
+        correlationId:
+          type: string
+          format: uuid
+        ipAddress:
+          type: string
+        userAgent:
+          type: string
+    PageResponseChangeAuditItem:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: "#/components/schemas/ChangeAuditItem"
+        totalElements:
+          type: integer
+          format: int64
+        totalPages:
+          type: integer
+          format: int32
+        page:
+          type: integer
+          format: int32
+        size:
+          type: integer
+          format: int32
+        totalIsExact:
+          type: boolean
+  securitySchemes:
+    bearerAuth:
+      type: http
+      description: "Token de acceso emitido por `POST /api/v1/auth/login`. Pegue solo\
+        \ el valor de `accessToken`: el prefijo `Bearer` lo añade la interfaz."
+      in: header
+      scheme: bearer
+      bearerFormat: JWT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@
 | Proyecto | NEXUS — Renovación de plataforma |
 | Empresa | FACTECH GROUP SAS |
 | Documento | `architecture.md` |
-| Versión | 0.14.0 |
+| Versión | 0.15.0 |
 | Estado | Borrador |
 | Responsable técnico | Bonilla Diaz William Steven |
 | Fecha de creación | 19-08-2026 |
@@ -398,6 +398,36 @@ Incluye `id` porque dos eventos pueden compartir instante, y sin desempate el or
 
 ---
 
+### 6.7 Registro de peticiones (`request_log`)
+
+**Existe desde `V35`, y hasta entonces era un hueco con forma de párrafo.** Cinco secciones de este documento lo daban por escrito —§6.6.1 lo cita como el otro extremo de `correlation_id`, §6.6.3 justifica en él la decisión de no llevar el motivo de eliminación en la URL, §8 dibuja su escritura fuera de la transacción, §9 le asigna la retención más corta y §11 su variable de entorno—, y la tabla no existía. La consecuencia no era teórica: §6.6.4 decide **no** auditar los `404`, los `400` de formato ni las peticiones mal dirigidas «porque `request_log` ya lo cubre», de modo que un **barrido de rutas** —el reconocimiento previo a un ataque— no dejaba rastro en ninguna parte del sistema.
+
+| Columna | Tipo | Por qué |
+|---|---|---|
+| `id` | `uuid` PK | `uuid` v7: ordenable por generación (§6.3) |
+| `occurred_at` | `timestamptz` NOT NULL | En UTC, como todo el sistema |
+| `correlation_id` | `uuid` NOT NULL | **Aquí no es nulable**, al contrario que en los cuatro registros de auditoría: aquellos admiten eventos de procesos internos, y esto solo lo escribe una petición HTTP |
+| `actor_id` | `uuid` NULL | **Nulo significa anónimo**, y es un dato. Sin clave foránea a `users`: la fila debe sobrevivir a la eliminación de la persona (§6.6.1) |
+| `method`, `path` | `varchar` NOT NULL | Qué se pidió |
+| `query_string` | `text` NULL | Los parámetros, tal como llegaron |
+| `status` | `smallint` NULL | **Nulo cuando la petición se abortó sin respuesta.** Un cero fingido diría que el sistema respondió cero |
+| `duration_ms` | `integer` NOT NULL | Lo que hace **verificables** los umbrales p95 del Art. XV.9, que hasta ahora no se podían medir porque no había de dónde |
+| `ip_address`, `user_agent` | `inet` / `text` NULL | El origen (Art. V.15) |
+
+**Ni cuerpo ni cabeceras, y no es una omisión.** Por ahí viajan contraseñas y tokens, y ningún saneador es de fiar sobre un contenido arbitrario: la única forma segura de no registrar un secreto es no registrar el cuerpo (Art. VI.5). El Art. XV.2 pide «parámetros», y eso es `query_string`.
+
+**Dónde se escribe.** En un filtro de servlet que **envuelve** al del límite de tasa y va **después** del de correlación: lo primero, para que un rechazo por ráfaga también quede registrado —si fuera al revés, el ataque más ruidoso sería el único invisible—; lo segundo, para que la fila lleve la misma correlación que el cliente recibe en su respuesta, que es lo que vuelve útil el identificador que se le muestra a quien reporta un error.
+
+**Fuera de la transacción de negocio y *best effort*** (Art. XV.7, §8): se escribe en una transacción propia una vez emitida la respuesta, y un fallo al registrar se anota en el log de aplicación sin alterar el resultado. Una operación revertida deja su fila igual — que el negocio fallara no significa que nadie llamara. Es la diferencia con los cuatro registros de auditoría, que se unen a la transacción de negocio y desaparecen con ella a propósito.
+
+**Qué queda fuera:** `/actuator/health`. La sonda del contenedor la llama cada diez segundos —unas ocho mil filas diarias en la tabla que más crece del sistema— y no responde ninguna pregunta: no es la petición de nadie, es el orquestador comprobando que el proceso vive.
+
+**El actor se apunta dentro de la cadena de seguridad**, no al escribir. Spring Security limpia su contexto en su propio `finally`, que corre **antes** que el de cualquier filtro que la envuelva: preguntándole al escribir, toda petición del sistema quedaría registrada como anónima, con filas que existen y parecen correctas. Lo copia un filtro colocado detrás de la autorización, mientras el dato todavía está.
+
+**Índices:** `(occurred_at DESC, id DESC)` para el listado cronológico, `(correlation_id)` para reconstruir una operación completa a partir del identificador que reportó el usuario, y `(actor_id, occurred_at DESC)` para «qué hizo esta persona». La purga sigue pendiente de **D-10**, que es quien fija los días.
+
+---
+
 ## 7. API
 
 ### 7.1 Convenciones
@@ -691,3 +721,4 @@ D-08 quedó cerrada en `security.md` §12, junto con las decisiones D-12 a D-15 
 | 0.12.0 | 24-08-2026 | Nueva tabla en §15 con [`ADR-001`](architecture/ADR-001-publicacion-del-contrato-openapi.md): el **contrato OpenAPI pasa a publicarse** como archivo versionado en `docs/api/openapi.json`, generado por `OpenApiContractIT` durante `mvn verify` y verificado en CI, que falla si lo comprometido no coincide con lo generado —el Art. VIII.6 hecho verificable—. Se descartó `springdoc-openapi-maven-plugin`, que arrancaría la aplicación una segunda vez cuando la suite ya la levanta con Testcontainers. Desbloquea `R-01` del frontend, que tenía cuarenta y dos de sus cuarenta y cuatro requerimientos detenidos. La consecuencia sobre `security.md` §6 se declara y se acepta: la reserva del contrato nunca fue un control, sino defensa en profundidad. | Responsable técnico |
 | 0.13.0 | 25-08-2026 | **Consecuencias de implementar los trece endpoints que faltaban del módulo** —`RF-SP-002` a `RF-SP-015`—. §7.4 declara que **`totalIsExact` deja de valer siempre verdadero**: sobre las tablas que crecen sin purga —los cuatro registros de auditoría— el conteo es **exacto hasta un techo** y aproximado por encima, contando sobre una subconsulta con `LIMIT techo + 1` que **nunca examina más filas que ese techo**, tenga la tabla mil o cien millones. El `COUNT(*)` exacto obliga a recorrer todas las filas que cumplen el predicado aunque solo se devuelvan veinte, y lo hace en cada página: con las tablas vacías no se nota y con dos años de operación son segundos por petición. Se declara además que **`totalPages` es una cota inferior** cuando el total no es exacto y que **pedir una página más allá sigue funcionando**, que es lo que impide que el techo se convierta en un muro; y que el ordenamiento **no siempre lo elige el cliente** —los listados de auditoría lo tienen fijo porque el orden es parte del significado de un registro cronológico—, que donde sí lo elige se resuelve contra una **lista blanca cerrada** antes de construir la consulta, y que a todo ordenamiento se le añade el identificador como **desempate**. §6.6.6 incorpora el **quinto índice mínimo**, `(occurred_at DESC, id DESC)`: los cuatro anteriores responden preguntas que empiezan por un filtro y **ninguno responde la del listado sin filtros**, que es la primera pantalla de los cuatro registros. Queda escrito por qué **no** se indexan `module`, `action`, `severity`, `outcome` ni `error_type` —columnas de dos o tres valores, que el planificador descarta— y que el coste no es neutro: **cada índice de estas tablas se paga en cada operación de negocio del sistema**. §6.6.4 fija por fin **cuándo la severidad de un rechazo es `ALTA`**: siete reglas que atacan la estructura del control de accesos, cada una con su motivo, frente al `MEDIA` por omisión de un duplicado o un padre inválido. | Responsable técnico |
 | 0.14.0 | 25-08-2026 | §7.2 declara por fin los dos códigos que la API ya devolvía sin estar en la tabla: **`423`** —la cuenta bloqueada, que `RF-SP-034` estrenó— y **`429`**, que entra con el límite de tasa (issue #21) y **lleva `Retry-After`**. Una tabla de códigos incompleta no es un detalle de redacción: es el documento al que se acude para saber qué puede recibir un cliente, y lo que no está en ella acaba tratándose como un error del servidor. | Responsable técnico |
+| 0.15.0 | 25-08-2026 | Nueva **§6.7: `request_log` existe** (issue #23, `V35`). Cinco secciones lo daban por escrito y la tabla no estaba, y el hueco no era teórico: §6.6.4 decide **no** auditar los `404`, los `400` de formato ni las peticiones mal dirigidas «porque `request_log` ya lo cubre», de modo que un **barrido de rutas** —el reconocimiento previo a un ataque— no dejaba rastro en ninguna parte. Se declaran las columnas y tres cosas que no se deducen del esquema: que `correlation_id` **no** es nulable aquí al contrario que en los cuatro registros de auditoría —aquellos admiten procesos internos, esto solo lo escribe una petición HTTP—; que **`status` nulo** significa que la petición se abortó sin respuesta, porque un cero fingido diría que el sistema respondió cero; y que el actor se apunta **dentro de la cadena de seguridad** y no al escribir, porque Spring Security limpia su contexto antes que el filtro que la envuelve y toda petición quedaría registrada como anónima — con filas que existen y parecen correctas. `duration_ms` vuelve **verificables** los umbrales p95 del Art. XV.9, que hasta ahora no se podían medir porque no había de dónde. La purga sigue pendiente de **D-10**. | Responsable técnico |

--- a/docs/modelo-datos.md
+++ b/docs/modelo-datos.md
@@ -2,11 +2,11 @@
 
 | Campo | Valor |
 |---|---|
-| Versión | 0.8.0 |
+| Versión | 0.9.0 |
 | Estado | **Borrador** |
 | Responsable | Bonilla Diaz William Steven |
 | Fecha de creación | 21-08-2026 |
-| Última actualización | 22-08-2026 |
+| Última actualización | 25-08-2026 |
 
 !!! info "Qué va en este documento"
 
@@ -282,14 +282,24 @@ erDiagram
     }
 
     request_log {
-        uuid id PK "esquema sin definir"
-        uuid correlation_id "referenciado por las cuatro"
+        uuid id PK "uuid v7"
+        timestamptz occurred_at "UTC"
+        uuid correlation_id "NOT NULL · aquí no es nulable"
+        uuid actor_id "NULL = anónimo · sin FK"
+        varchar method "GET POST PUT PATCH DELETE"
+        varchar path "ruta sin cuerpo ni cabeceras"
+        text query_string "NULL · los parámetros"
+        smallint status "NULL = abortada sin respuesta"
+        integer duration_ms "umbrales p95 del Art XV.9"
+        inet ip_address "NULL"
+        text user_agent "NULL"
     }
 ```
 
 - **Las tres columnas de origen son nulables a la vez**, con un `CHECK` que lo impone: `correlation_id` e `ip_address` van juntas. Una fila sin IP significa «no vino de la red», nunca «se olvidó registrarla».
 - **`audit_security_log` es de solo inserción**, restringido a nivel de privilegios de base de datos y no por convención en el código. Un registro que la aplicación puede reescribir no prueba nada.
 - Las cuatro se leen en conjunto por una **vista de solo lectura** sobre el núcleo común, que exige los cuatro permisos de lectura.
+- **`request_log` ya no es un hueco**: existe desde `V35` (issue #23) y `architecture.md` §6.7 declara el porqué de cada columna. Dos diferencias con las cuatro de arriba, y ninguna es de estilo: su `correlation_id` **no** es nulable —aquellas admiten eventos de procesos internos, esto solo lo escribe una petición HTTP— y **no participa en la transacción de negocio**, de modo que una operación revertida deja su fila igual: que el negocio fallara no significa que nadie llamara.
 
 ---
 
@@ -327,7 +337,7 @@ flowchart TB
         C6["user_memberships"]
     end
 
-    OBS["request_log<br/>esquema sin definir"]
+    OBS["request_log<br/>V35 · escrita"]
 
     A1 --> A3
     A2 --> A3
@@ -352,7 +362,9 @@ flowchart TB
     class Q2,Q3,OBS,C1,C2,C3,C4,C5,C6 pend
 ```
 
-De las dieciséis tablas del dibujo, **siete están escritas** —`permissions`, las cuatro de auditoría, `roles` y `role_permissions`, en `V1` a `V7`—. De las nueve restantes, siete tienen migración declarada en algún `plan.md`, de `V13` a `V21`. Las dos que no: **`refresh_tokens`**, que crea `RF-SP-034`, y **`password_reset_tokens`**, que crea `RF-SP-040`. Ninguno de esos dos requerimientos tiene `plan.md` todavía, de modo que son las únicas tablas del modelo sin sitio asignado en la secuencia de migraciones.
+**Actualizado el 25-08-2026:** de las dieciséis tablas del dibujo **quince están escritas**, de `V1` a `V35`. La que falta es **`password_reset_tokens`**, que crea `RF-SP-040` —el único requerimiento del grupo sin `plan.md`—, y es por tanto la única tabla del modelo sin sitio asignado en la secuencia de migraciones. `refresh_tokens` dejó de estarlo al implementarse `RF-SP-034`, y `request_log` al cerrarse el issue #23 en `V35`.
+
+**Sobre la numeración de las migraciones.** La secuencia no es continua —falta el tramo `V8` a `V12`— y no es un descuido: esos números quedaron reservados en `plan.md` que se escribieron antes y se implementaron después, y Flyway **aborta el arranque** ante una migración fuera de orden sobre una base ya migrada. Cada archivo afectado lo explica en su cabecera.
 
 ---
 
@@ -362,7 +374,7 @@ De las dieciséis tablas del dibujo, **siete están escritas** —`permissions`,
 |---|---|---|
 | ~~1~~ | ~~**`memberships` no tiene vínculo con nada.**~~ **Resuelto el 22-08-2026 al aprobar el `plan.md` de `RF-SP-024`:** la asociación vive en **`user_memberships`**, tabla puente con `user_id` como **clave primaria** —que es `RN-SP-014` declarada en el esquema: una membresía por persona—. No es `users.membership_id` porque la asignación lleva vigencia propia, ni una columna en `roles` porque el nivel es de la persona y no del rol. La restricción de que solo los consumidores la tengan (`RN-SP-013`, `RN-SP-018`) **no** es expresable en el esquema: depende de `user_roles` y `roles.role_type`, y PostgreSQL no admite subconsultas en `CHECK` | — |
 | 2 | **`countries` y `currencies` son islas.** Existen sin una sola clave foránea entrante. Su razón de ser es futura —importes con moneda, direcciones con país—, pero conviene dejar escrito quién los referenciará. | `modules.md` §6, alcance por inventariar |
-| 3 | **`request_log` no tiene esquema.** Las cuatro tablas de auditoría lo referencian por `correlation_id` y `RF-SP-011` lo menciona en su postcondición, pero no hay columnas descritas en ningún documento. | `architecture.md` §9 |
+| ~~3~~ | ~~**`request_log` no tiene esquema.**~~ **Resuelto el 25-08-2026 (issue #23):** la tabla se crea en `V35` y sus columnas quedan declaradas en `architecture.md` §6.7 y en §3 de este documento. El hueco no era de documentación: la tabla **no existía**, y cinco secciones de la arquitectura la daban por escrita. Lo que se perdía mientras tanto era todo lo que el manejador global decide no auditar «porque `request_log` ya lo cubre» — los `404`, los `400` de formato y el barrido de rutas | `architecture.md` §6.7 |
 | 4 | **`audit_*.actor_id` no declara clave foránea a `users`.** Está documentado como `uuid NULL` sin relación. Si es deliberado —para que eliminar un usuario no arrastre ni bloquee su auditoría— conviene decirlo; si no, falta la restricción. | `architecture.md` §6.6.1 |
 | 5 | **Tres estrategias de baja distintas**: `roles` con `deleted_at`, `countries` y `currencies` con `is_active`, `memberships` con ninguna. Cada caso está justificado por separado, pero no hay una regla que diga cuándo se usa cada una. | `architecture.md` §6.4 |
 | 6 | **`modelo_v1.mwb` está desactualizado.** Trae `roles.assigned_role_id`, que `security.md` §9 renombra a `parent_role_id`. El modelo gráfico es material de referencia, no autoridad sobre el esquema (Art. V.3). | `DB/modelo_v1.mwb` |
@@ -385,3 +397,4 @@ De las dieciséis tablas del dibujo, **siete están escritas** —`permissions`,
 | 0.6.0 | 22-08-2026 | Entidad nueva `user_supervisors`, derivada de registrar `RF-SP-041` y `RF-SP-042`: la estructura comercial **persona → persona**, con historial y un solo superior vigente por persona. Es la primera tabla del modelo que relaciona dos usuarios entre sí. Se anota por qué lleva clave sustituta cuando las demás asociaciones no la llevan, y que **no concede alcance sobre los datos** —D-22 sigue abierta—. | Responsable técnico |
 | 0.7.0 | 22-08-2026 | Consecuencias de aprobar los `plan.md` de `RF-SP-025` a `RF-SP-029`. `users` incorpora **`deleted_at`**, que nace con la tabla en `V18` y no con `RF-SP-029` —`architecture.md` §6.4 la declara obligatoria en toda tabla de negocio y diez requerimientos la leen antes de que alguien la escriba—, y se anota qué requerimiento crea cada una de las tres columnas de control de acceso: las tres son de `RF-SP-034`. §1 incorpora **`user_memberships`**, que faltaba en el diagrama pese a haberla creado `RF-SP-024` \(`V20`\), y con ella queda **cerrado el hueco 1** de §5: la asociación entre una persona y su nivel vive en esa tabla puente, con `user_id` como clave primaria. | Responsable técnico |
 | 0.8.0 | 22-08-2026 | Revisión de completitud disparada por los flujos del módulo v0.3.0. §1 incorpora **`users.password_expires_at`** —`RF-SP-038` §7 exige fijar cuándo caduca la credencial provisional y el modelo solo declaraba la marca— y la tabla **`password_reset_tokens`**, que el permiso temporal de un solo uso de `RF-SP-040` exige y que no puede ser una columna porque tiene vigencia, consumo e invalidación propios. §4 añade `user_memberships`, que faltaba en el mapa, retira la pregunta «¿quién apunta aquí?» de `memberships` —`user_memberships` la responde desde la v0.7.0— y anota qué tablas están escritas y cuáles no tienen sitio en la secuencia de migraciones. La advertencia de cabecera deja de decir que no hay ninguna migración escrita: de `V1` a `V7` lo están. §5 suma cuatro pendientes: `role_permissions` ante el borrado lógico de un rol, las dos tablas sin migración declarada, la purga que nadie ejecuta y `PENDIENTE` sin transiciones. | Responsable técnico |
+| 0.9.0 | 25-08-2026 | **`request_log` deja de ser un hueco** (issue #23). §3 sustituye el marcador «esquema sin definir» por las once columnas reales que crea `V35`, §4 la marca como escrita en el mapa y §5 cierra el **pendiente 3**. Se anota lo que no se deduce del esquema: su `correlation_id` **no** es nulable al contrario que en las cuatro de auditoría —aquellas admiten eventos de procesos internos, esto solo lo escribe una petición HTTP—, un `status` nulo significa que la petición se abortó sin respuesta, y **no participa en la transacción de negocio**, de modo que una operación revertida deja su fila igual. Sigue faltando la purga, que depende de **D-10** (pendiente 9). | Responsable técnico |

--- a/src/main/java/com/factech/nexus/shared/observability/RequestActor.java
+++ b/src/main/java/com/factech/nexus/shared/observability/RequestActor.java
@@ -1,0 +1,42 @@
+package com.factech.nexus.shared.observability;
+
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Quién resultó ser el actor de la petición en curso, para quien lo necesite <b>al terminar</b>.
+ *
+ * <p><b>Por qué hace falta esto y no basta con preguntar al contexto de seguridad.</b> Spring
+ * Security <b>limpia su contexto</b> en su propio {@code finally}, y esa limpieza ocurre
+ * <b>antes</b> que la de cualquier filtro que lo envuelva: para cuando {@link RequestLogFilter}
+ * escribe su fila —después de emitida la respuesta— el actor ya no está, y toda petición del
+ * sistema quedaría registrada como anónima. El síntoma es engañoso, porque la fila existe y parece
+ * correcta.
+ *
+ * <p>Se apunta mientras el actor <b>sí</b> se conoce —dentro de la cadena de seguridad, en {@link
+ * com.factech.nexus.shared.security.ActorCaptureFilter}— y se lee al final.
+ *
+ * <p><b>Un {@code ThreadLocal} exige limpiarlo.</b> Los hilos del contenedor se reutilizan: uno
+ * olvidado le atribuiría a la siguiente petición el actor de esta, que en un registro de auditoría
+ * es peor que no tener el dato. Lo limpia quien lo lee.
+ */
+public final class RequestActor {
+
+  private static final ThreadLocal<UUID> ACTUAL = new ThreadLocal<>();
+
+  private RequestActor() {}
+
+  /** Apunta el actor ya resuelto. Un nulo significa anónimo y también es un dato. */
+  public static void bind(UUID actorId) {
+    ACTUAL.set(actorId);
+  }
+
+  /** El actor de la petición en curso, o vacío si nunca llegó a resolverse. */
+  public static Optional<UUID> current() {
+    return Optional.ofNullable(ACTUAL.get());
+  }
+
+  public static void unbind() {
+    ACTUAL.remove();
+  }
+}

--- a/src/main/java/com/factech/nexus/shared/observability/RequestLogFilter.java
+++ b/src/main/java/com/factech/nexus/shared/observability/RequestLogFilter.java
@@ -1,0 +1,116 @@
+package com.factech.nexus.shared.observability;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Registra <b>toda</b> petición en {@code request_log} (Art. XV.2 y XV.4, issue #23).
+ *
+ * <p><b>Toda</b> significa toda: la que triunfa, la que devuelve `404`, la que se rechaza por
+ * formato, la que topa con el límite de tasa y la que revienta. Ese era el hueco — el manejador
+ * global decide <b>no</b> auditar los `404`, los `400` de formato y las peticiones mal dirigidas
+ * «porque `request_log` ya lo cubre», y la tabla no existía: no las cubría nadie. Un barrido de
+ * rutas, que es el reconocimiento previo a un ataque, no dejaba rastro en ninguna parte.
+ *
+ * <p><b>Dónde va en la cadena, y por qué ahí.</b> Después de {@link CorrelationFilter}, para que la
+ * fila lleve la correlación que el cliente recibe en la respuesta y la IP ya resuelta; y
+ * <b>envolviendo</b> al límite de tasa, para que un rechazo por ráfaga también quede registrado —
+ * si fuera al revés, el ataque más ruidoso sería el único invisible.
+ *
+ * <p><b>Se escribe después de la respuesta y nunca puede tumbarla</b> (Art. XV.7). Un fallo al
+ * registrar se anota en el log de aplicación con su correlación y ahí termina: la petición ya se
+ * respondió, y convertir un apunte fallido en un `500` sería exactamente lo que ese artículo
+ * prohíbe.
+ *
+ * <p><b>Ni cuerpo ni cabeceras.</b> Ahí viajan contraseñas y tokens, y ningún saneador es de fiar
+ * sobre un contenido arbitrario: la única forma segura de no registrar un secreto es no registrar
+ * el cuerpo (Art. VI.5).
+ */
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE + 15)
+public class RequestLogFilter extends OncePerRequestFilter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RequestLogFilter.class);
+
+  private final RequestLogWriter registro;
+
+  public RequestLogFilter(RequestLogWriter registro) {
+    this.registro = registro;
+  }
+
+  /**
+   * La salud queda fuera.
+   *
+   * <p>La sonda del contenedor la llama cada diez segundos: registrarla llenaría la tabla que más
+   * crece del sistema con ocho mil filas diarias que no responden ninguna pregunta. No es una
+   * petición de nadie, es el orquestador comprobando que el proceso vive.
+   */
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest peticion) {
+    return peticion.getRequestURI().startsWith("/actuator/health");
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest peticion, HttpServletResponse respuesta, FilterChain cadena)
+      throws ServletException, IOException {
+
+    long inicio = System.nanoTime();
+    try {
+      cadena.doFilter(peticion, respuesta);
+    } finally {
+      long duracionMs = (System.nanoTime() - inicio) / 1_000_000;
+      anotar(peticion, respuesta, duracionMs);
+      // Los hilos del contenedor se reutilizan: un actor olvidado le
+      // atribuiria a la siguiente peticion el de esta.
+      RequestActor.unbind();
+    }
+  }
+
+  /**
+   * El apunte, en el {@code finally}: también cuando la petición terminó en excepción.
+   *
+   * <p>El actor <b>no se le pregunta al contexto de seguridad</b>, y ese detalle costó una prueba
+   * en rojo: Spring Security limpia el suyo en su propio {@code finally}, que corre <b>antes</b>
+   * que este por estar por dentro. Preguntándole aquí, toda petición del sistema quedaría
+   * registrada como anónima — con filas que existen y parecen correctas. Lo apunta {@code
+   * ActorCaptureFilter} mientras todavía se conoce, y aquí solo se recoge.
+   */
+  private void anotar(HttpServletRequest peticion, HttpServletResponse respuesta, long duracionMs) {
+    try {
+      RequestContext contexto = RequestContext.current().orElse(null);
+      UUID correlacion = contexto == null ? UUID.randomUUID() : contexto.correlationId();
+
+      registro.registrar(
+          correlacion,
+          RequestActor.current().orElse(null),
+          peticion.getMethod(),
+          peticion.getRequestURI(),
+          peticion.getQueryString(),
+          respuesta.getStatus(),
+          duracionMs,
+          contexto == null ? null : contexto.ipAddress(),
+          contexto == null ? null : contexto.userAgent());
+
+    } catch (RuntimeException fallo) {
+      // Art. XV.7: registrar no puede alterar el resultado de la operación. La
+      // respuesta ya salió; lo único sensato es dejar constancia de que el
+      // registro dejó de escribir, que es lo que permite detectarlo.
+      LOG.error(
+          "No se pudo registrar la petición {} {}",
+          peticion.getMethod(),
+          peticion.getRequestURI(),
+          fallo);
+    }
+  }
+}

--- a/src/main/java/com/factech/nexus/shared/observability/RequestLogWriter.java
+++ b/src/main/java/com/factech/nexus/shared/observability/RequestLogWriter.java
@@ -1,0 +1,83 @@
+package com.factech.nexus.shared.observability;
+
+import com.factech.nexus.shared.persistence.UuidV7Generator;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Escribe una fila en {@code request_log} (Art. XV.2, issue #23).
+ *
+ * <p><b>Transacción propia y nunca la de negocio</b> (Art. XV.7). La fila se escribe <b>después</b>
+ * de emitida la respuesta, de modo que un fallo al registrar no puede tumbar la operación — y, al
+ * revés, una operación revertida sí deja su rastro: que el negocio fallara no significa que la
+ * petición no ocurriera. Es exactamente la diferencia con los cuatro registros de auditoría, que se
+ * unen a la transacción precisamente para desaparecer con ella.
+ *
+ * <p><b>Se usa {@code JdbcTemplate} y no una entidad JPA.</b> La tabla no tiene comportamiento ni
+ * invariantes que proteger: es un apunte. Mapearla como entidad la metería en el contexto de
+ * persistencia de cada petición —con su comprobación de cambios y su vaciado— para escribir una
+ * fila que nadie vuelve a leer en esa misma petición.
+ */
+@Component
+public class RequestLogWriter {
+
+  private static final String INSERTAR =
+      """
+      INSERT INTO request_log (id, occurred_at, correlation_id, actor_id, method, path,
+                               query_string, status, duration_ms, ip_address, user_agent)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, cast(? AS inet), ?)
+      """;
+
+  /** Lo que la columna admite. Se recorta en lugar de fallar: un apunte no rechaza. */
+  private static final int LARGO_MAXIMO_RUTA = 2048;
+
+  private final JdbcTemplate jdbc;
+  private final UuidV7Generator ids;
+
+  public RequestLogWriter(JdbcTemplate jdbc, UuidV7Generator ids) {
+    this.jdbc = jdbc;
+    this.ids = ids;
+  }
+
+  /**
+   * @param actorId nulo significa <b>anónimo</b>, no que se perdiera el dato (Art. XV.2)
+   * @param status nulo cuando la petición se abortó sin llegar a responder
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void registrar(
+      UUID correlacion,
+      UUID actorId,
+      String metodo,
+      String ruta,
+      String parametros,
+      Integer status,
+      long duracionMs,
+      String ip,
+      String agente) {
+
+    jdbc.update(
+        INSERTAR,
+        ids.next(),
+        OffsetDateTime.now(),
+        correlacion,
+        actorId,
+        metodo,
+        recortar(ruta, LARGO_MAXIMO_RUTA),
+        parametros,
+        status,
+        duracionMs,
+        ip,
+        agente);
+  }
+
+  private static String recortar(String valor, int largo) {
+    if (valor == null) {
+      return null;
+    }
+    return valor.length() <= largo ? valor : valor.substring(0, largo);
+  }
+}

--- a/src/main/java/com/factech/nexus/shared/security/ActorCaptureFilter.java
+++ b/src/main/java/com/factech/nexus/shared/security/ActorCaptureFilter.java
@@ -1,0 +1,42 @@
+package com.factech.nexus.shared.security;
+
+import com.factech.nexus.shared.observability.RequestActor;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+/**
+ * Apunta quién resultó ser el actor, mientras el contexto de seguridad todavía existe (issue #23).
+ *
+ * <p><b>Vive dentro de la cadena de seguridad y no fuera</b>, y ese es todo el motivo de que
+ * exista: Spring Security limpia su contexto en su propio {@code finally}, de modo que un filtro
+ * que la envuelva —como el que escribe {@code request_log}— ya no encuentra al actor cuando le toca
+ * escribir. Registraría toda petición como anónima, con filas que existen y parecen correctas.
+ *
+ * <p><b>Qué queda anónimo, y es lo correcto:</b> lo que la cadena rechaza antes de llegar aquí. Un
+ * {@code 401} no tiene actor porque, en efecto, no lo hubo.
+ *
+ * <p>No decide nada ni puede fallar: solo copia un dato que ya está resuelto.
+ */
+@Component
+public class ActorCaptureFilter extends OncePerRequestFilter {
+
+  private final CurrentActor actor;
+
+  public ActorCaptureFilter(CurrentActor actor) {
+    this.actor = actor;
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest peticion, HttpServletResponse respuesta, FilterChain cadena)
+      throws ServletException, IOException {
+
+    actor.currentActorId().ifPresent(RequestActor::bind);
+    cadena.doFilter(peticion, respuesta);
+  }
+}

--- a/src/main/java/com/factech/nexus/shared/security/SecurityConfig.java
+++ b/src/main/java/com/factech/nexus/shared/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.access.intercept.AuthorizationFilter;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 
 /**
@@ -67,11 +68,14 @@ public class SecurityConfig {
 
   private final boolean documentacionPublica;
   private final JwtActorConverter actorDesdeElToken;
+  private final ActorCaptureFilter actorParaElRegistro;
 
   public SecurityConfig(
       JwtActorConverter actorDesdeElToken,
+      ActorCaptureFilter actorParaElRegistro,
       @Value("${nexus.security.expose-api-docs:false}") boolean documentacionPublica) {
     this.actorDesdeElToken = actorDesdeElToken;
+    this.actorParaElRegistro = actorParaElRegistro;
     this.documentacionPublica = documentacionPublica;
   }
 
@@ -116,6 +120,13 @@ public class SecurityConfig {
         // token expire (`security.md` §4.5).
         .oauth2ResourceServer(
             oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(actorDesdeElToken)))
+
+        // Apunta el actor DENTRO de esta cadena, que es el único sitio donde
+        // todavía existe: Spring Security limpia su contexto en su propio
+        // `finally`, antes que el de cualquier filtro que la envuelva. Sin esto,
+        // `request_log` registraría toda petición como anónima — con filas que
+        // existen y parecen correctas, que es la peor forma de equivocarse.
+        .addFilterAfter(actorParaElRegistro, AuthorizationFilter.class)
         .headers(Customizer.withDefaults());
 
     return http.build();

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -89,6 +89,10 @@ nexus:
     count-limit: 10000
 
   audit:
+    # Retención del `request_log`. HOY NO LA LEE NADIE, y decirlo aquí evita la
+    # peor confusión posible: creer que la purga está activa porque el valor
+    # está puesto. La tabla existe desde `V35` (issue #23) y crece sin techo
+    # hasta que D-10 fije los días y alguien escriba el proceso que los aplica.
     request-log-retention-days: ${REQUEST_LOG_RETENTION_DAYS:}
 
   security:

--- a/src/main/resources/db/migration/V35__create_request_log.sql
+++ b/src/main/resources/db/migration/V35__create_request_log.sql
@@ -1,0 +1,87 @@
+-- =============================================================================
+-- Issue #23 — `request_log`: qué se le pidió al sistema y qué respondió.
+--
+-- POR QUÉ ESTA TABLA NO EXISTÍA Y HACÍA FALTA. El Art. XV.2 la exige desde el
+-- primer día, y SIETE PUNTOS DEL CÓDIGO ya contaban con ella para decidir NO
+-- auditar: el manejador global no registra los `404`, los `400` de formato ni
+-- las peticiones mal dirigidas «porque `request_log` ya lo cubre», y el
+-- `X-Correlation-Id` que se devuelve en cada respuesta se documenta como la
+-- forma de localizar la petición «en `request_log`». Sin la tabla, todo eso era
+-- una promesa: un barrido de rutas, un `404` o un `400` no dejaban rastro en
+-- ninguna parte, y el identificador de correlación apuntaba a un sitio vacío.
+--
+-- QUÉ RESPONDE, Y EN QUÉ SE DISTINGUE DE LA AUDITORÍA (Art. XV.3). Esta tabla
+-- responde «qué se le pidió al sistema y qué respondió»; los cuatro registros de
+-- auditoría responden «qué cambió en el negocio, quién lo cambió y por qué».
+-- Se correlacionan por `correlation_id`, y se separan porque se consultan por
+-- motivos distintos, se retienen por plazos distintos (Art. XV.8) y crecen a
+-- ritmos muy distintos.
+--
+-- LO QUE NO SE GUARDA, Y ES TAN DECISIÓN COMO LO QUE SÍ:
+--   * El CUERPO de la petición. Ahí viajan contraseñas, y el Art. VI.5 prohíbe
+--     que un registro las contenga. Ningún saneador es de fiar sobre un cuerpo
+--     arbitrario: la única forma segura de no registrar un secreto es no
+--     registrar el cuerpo.
+--   * Las CABECERAS, y `Authorization` en particular, por lo mismo.
+--   * El `query_string` SÍ se guarda —el Art. XV.2 pide «parámetros»— y por eso
+--     ningún endpoint del sistema admite secretos por ahí: el motivo de una
+--     eliminación viaja en el cuerpo justamente para no acabar en este registro
+--     ni en el de un proxy.
+--
+-- POR QUÉ `status` ES NULABLE. Si el contenedor aborta la petición antes de
+-- producir respuesta —una conexión cortada a media escritura—, no hay código que
+-- registrar. Un cero fingido diría que el sistema respondió cero, que no existe;
+-- el nulo dice lo que ocurrió: no hubo respuesta.
+--
+-- CRECIMIENTO. Es la tabla que más crece del sistema —una fila por petición— y
+-- NO tiene purga todavía: la retención concreta es la decisión **D-10**, con su
+-- propio issue. Los índices se dejan al mínimo por el mismo motivo que en los
+-- registros de auditoría: cada uno se paga en cada petición.
+-- =============================================================================
+
+CREATE TABLE request_log (
+    id             uuid        PRIMARY KEY,
+    occurred_at    timestamptz NOT NULL,
+    correlation_id uuid        NOT NULL,
+
+    -- Nulo significa ANÓNIMO, no «se perdió el dato» (Art. XV.2): las rutas
+    -- públicas —inicio de sesión, refresco, cierre— se llaman sin actor.
+    actor_id       uuid        NULL,
+
+    method         varchar(10)  NOT NULL,
+    path           varchar(2048) NOT NULL,
+    query_string   text         NULL,
+    status         smallint     NULL,
+    duration_ms    integer      NOT NULL,
+    ip_address     inet         NULL,
+    user_agent     text         NULL,
+
+    CONSTRAINT ck_request_log_status
+        CHECK (status IS NULL OR (status BETWEEN 100 AND 599)),
+
+    -- Una duración negativa solo puede venir de un reloj que retrocedió o de un
+    -- cálculo mal hecho; en ambos casos es un defecto y no un dato.
+    CONSTRAINT ck_request_log_duration CHECK (duration_ms >= 0)
+);
+
+COMMENT ON TABLE request_log IS
+    'Qué se le pidió al sistema y qué respondió (Art. XV.2). Append-only. Sin cuerpo ni cabeceras.';
+COMMENT ON COLUMN request_log.actor_id IS
+    'Nulo = anónimo. Sin clave foránea a users: la fila debe sobrevivir a la eliminación de la persona.';
+COMMENT ON COLUMN request_log.status IS
+    'Nulo cuando la petición se abortó sin respuesta. Un cero fingido diría que el sistema respondió cero.';
+COMMENT ON COLUMN request_log.duration_ms IS
+    'Lo que permite medir los umbrales p95 del Art. XV.9, que hasta ahora eran inverificables.';
+
+-- La línea de tiempo: «las últimas peticiones», que es la consulta por defecto.
+-- Con `id` como desempate por el mismo motivo que en los registros de auditoría:
+-- dos peticiones pueden compartir instante, y al ser UUID v7 el desempate sigue
+-- siendo cronológico.
+CREATE INDEX ix_request_log_occurred_at ON request_log (occurred_at DESC, id DESC);
+
+-- El enlace con los cuatro registros de auditoría (Art. XV.3). Es la consulta
+-- que responde «qué más pasó en la petición que produjo este evento».
+CREATE INDEX ix_request_log_correlation_id ON request_log (correlation_id);
+
+-- «Todo lo que pidió esta persona», que es la investigación más frecuente.
+CREATE INDEX ix_request_log_actor ON request_log (actor_id, occurred_at DESC);

--- a/src/test/java/com/factech/nexus/shared/architecture/OpenApiContractIT.java
+++ b/src/test/java/com/factech/nexus/shared/architecture/OpenApiContractIT.java
@@ -34,6 +34,9 @@ class OpenApiContractIT extends IntegrationTestBase {
   /** Destino del contrato publicado. Relativo a la raíz del proyecto (ADR-001). */
   private static final Path DESTINO = Path.of("docs", "api", "openapi.json");
 
+  /** El mismo contrato en YAML, que es el formato que asumen los generadores de cliente. */
+  private static final Path DESTINO_YAML = Path.of("docs", "api", "openapi.yaml");
+
   @Autowired private MockMvc mvc;
   @Autowired private ObjectMapper json;
 
@@ -417,5 +420,33 @@ class OpenApiContractIT extends IntegrationTestBase {
         DESTINO,
         ordenado.writerWithDefaultPrettyPrinter().writeValueAsString(contenido) + "\n",
         StandardCharsets.UTF_8);
+  }
+
+  @Test
+  @DisplayName("publica también el YAML, que es lo que piden por defecto los generadores")
+  void publicaElContratoTambienEnYaml() throws Exception {
+    // El JSON basta para leerlo; el YAML es lo que la mayoría de los
+    // generadores de cliente asume cuando se les da una URL. Publicar solo uno
+    // obliga a cada consumidor a convertirlo, y una conversión hecha a mano en
+    // el lado del cliente es una copia del contrato que envejece por su cuenta.
+    //
+    // Se pide a springdoc en lugar de convertir el JSON aquí: así el YAML lo
+    // produce el mismo componente que sirve `/v3/api-docs.yaml` en ejecución, y
+    // no una traducción propia que pudiera diferir de lo que ve quien consulta
+    // la API en vivo.
+    String cuerpo =
+        mvc.perform(get("/v3/api-docs.yaml").with(user("doc")))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString(StandardCharsets.UTF_8);
+
+    Files.createDirectories(DESTINO_YAML.getParent());
+    Files.writeString(DESTINO_YAML, cuerpo, StandardCharsets.UTF_8);
+
+    // Que no salga vacío es lo único que esta prueba puede afirmar por su
+    // cuenta: la coincidencia con el JSON la garantiza el propio springdoc, y
+    // que lo comprometido esté al día lo comprueba CI.
+    org.assertj.core.api.Assertions.assertThat(cuerpo).contains("openapi:").contains("/api/v1/");
   }
 }

--- a/src/test/java/com/factech/nexus/shared/observability/RequestLogIT.java
+++ b/src/test/java/com/factech/nexus/shared/observability/RequestLogIT.java
@@ -1,0 +1,171 @@
+package com.factech.nexus.shared.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.factech.nexus.IntegrationTestBase;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.web.servlet.MockMvc;
+
+/**
+ * El registro de peticiones (Art. XV.2 y XV.4, issue #23).
+ *
+ * <p>Lo que estas pruebas vigilan es <b>lo que antes no dejaba rastro</b>: un `404`, un `400` de
+ * formato, un barrido de rutas. El manejador global decide no auditar esos casos «porque
+ * `request_log` ya lo cubre», y hasta ahora la tabla no existía — de modo que no los cubría nadie.
+ */
+@AutoConfigureMockMvc
+class RequestLogIT extends IntegrationTestBase {
+
+  private static final String SUPERADMIN_ROL = "01a02a33-4c00-7001-9c4f-5e7ad1000001";
+
+  @Autowired private MockMvc mvc;
+  @Autowired private JdbcTemplate jdbc;
+
+  @BeforeEach
+  void empezarConLaTablaVacia() {
+    jdbc.update("DELETE FROM request_log");
+  }
+
+  @Test
+  @DisplayName("una petición atendida deja su fila, con todo lo que el Art. XV.2 exige")
+  void laPeticionAtendidaSeRegistra() throws Exception {
+    // La consulta va en la URL y no con `.param()`: aquella la rellena MockMvc
+    // sin tocar el `query string`, y lo que esta prueba comprueba es justo que
+    // los parámetros quedan registrados como llegan en un contenedor real.
+    mvc.perform(
+            get("/api/v1/roles?size=5")
+                .with(user(SUPERADMIN.toString()).authorities(() -> "roles:read")))
+        .andExpect(status().isOk());
+
+    Map<String, Object> fila = ultima();
+
+    assertThat(fila.get("method")).isEqualTo("GET");
+    assertThat(fila.get("path")).isEqualTo("/api/v1/roles");
+    assertThat(fila.get("query_string")).isEqualTo("size=5");
+    assertThat(((Number) fila.get("status")).intValue()).isEqualTo(200);
+    assertThat(fila.get("correlation_id")).isNotNull();
+    // La duración es lo que hace verificables los umbrales p95 del Art. XV.9,
+    // que hasta ahora no se podían medir porque no había de dónde.
+    assertThat(((Number) fila.get("duration_ms")).longValue()).isGreaterThanOrEqualTo(0);
+    // Autenticada: el actor no es anónimo. Se lee al TERMINAR la petición,
+    // porque al empezar el filtro la seguridad todavía no ha resuelto nada.
+    assertThat(fila.get("actor_id")).isEqualTo(SUPERADMIN);
+  }
+
+  @Test
+  @DisplayName("el `404` deja rastro: es lo que el manejador global da por hecho y faltaba")
+  void elCuatrocientosCuatroSeRegistra() throws Exception {
+    mvc.perform(
+            get("/api/v1/roles/{id}", UUID.randomUUID())
+                .with(user(SUPERADMIN.toString()).authorities(() -> "roles:read")))
+        .andExpect(status().isNotFound());
+
+    assertThat(((Number) ultima().get("status")).intValue()).isEqualTo(404);
+  }
+
+  @Test
+  @DisplayName("un barrido de rutas inexistentes queda registrado entero")
+  void elBarridoDeRutasQuedaRegistrado() throws Exception {
+    // El reconocimiento previo a un ataque es exactamente esto: peticiones que
+    // no llegan a ejecutar nada. Antes eran invisibles.
+    for (String ruta : java.util.List.of("/api/v1/admin", "/api/v1/.env", "/api/v1/config")) {
+      mvc.perform(get(ruta).with(user("curioso")));
+    }
+
+    assertThat(cuantas()).isEqualTo(3);
+  }
+
+  @Test
+  @DisplayName("el `400` de formato también, y sin el cuerpo que lo provocó")
+  void elCuatrocientosSeRegistraSinCuerpo() throws Exception {
+    mvc.perform(
+            post("/api/v1/roles")
+                .with(user(SUPERADMIN.toString()).authorities(() -> "roles:create"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"code\":\"\",\"secreto\":\"ClaveSuperSecreta2026\"}"))
+        .andExpect(status().isBadRequest());
+
+    Map<String, Object> fila = ultima();
+    assertThat(((Number) fila.get("status")).intValue()).isEqualTo(400);
+
+    // NI CUERPO NI CABECERAS. Ahí viajan contraseñas, y ningún saneador es de
+    // fiar sobre un contenido arbitrario: la única forma segura de no registrar
+    // un secreto es no registrar el cuerpo (Art. VI.5).
+    assertThat(fila.toString()).doesNotContain("ClaveSuperSecreta2026");
+    assertThat(fila).doesNotContainKeys("body", "headers");
+  }
+
+  @Test
+  @DisplayName("la correlación de la fila es la MISMA que el cliente recibió en la respuesta")
+  void laCorrelacionEnlazaConLaRespuesta() throws Exception {
+    String devuelta =
+        mvc.perform(
+                get("/api/v1/permissions")
+                    .with(user(SUPERADMIN.toString()).authorities(() -> "permissions:read")))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getHeader("X-Correlation-Id");
+
+    // Es lo que hace útil al identificador que se le muestra a quien reporta un
+    // error: sin esta igualdad, citarlo no lleva a ninguna parte.
+    assertThat(ultima().get("correlation_id")).hasToString(devuelta);
+  }
+
+  @Test
+  @DisplayName("una petición anónima se registra con actor nulo, que significa anónimo")
+  void laPeticionAnonimaSeRegistra() throws Exception {
+    mvc.perform(get("/api/v1/roles")).andExpect(status().isUnauthorized());
+
+    Map<String, Object> fila = ultima();
+    assertThat(((Number) fila.get("status")).intValue()).isEqualTo(401);
+    assertThat(fila.get("actor_id")).isNull();
+  }
+
+  @Test
+  @DisplayName("la sonda de salud NO se registra: son ocho mil filas diarias que no dicen nada")
+  void laSondaDeSaludNoSeRegistra() throws Exception {
+    mvc.perform(get("/actuator/health")).andExpect(status().isOk());
+
+    assertThat(cuantas()).isZero();
+  }
+
+  @Test
+  @DisplayName("el registro sobrevive a una operación revertida: la petición ocurrió igual")
+  void laOperacionFallidaTambienDejaRastro() throws Exception {
+    // Es la diferencia con los cuatro registros de auditoría, que se unen a la
+    // transacción de negocio para desaparecer con ella. Este va aparte a
+    // propósito (Art. XV.7): que el negocio fallara no significa que nadie
+    // llamara.
+    mvc.perform(
+            post("/api/v1/roles")
+                .with(user(SUPERADMIN.toString()).authorities(() -> "roles:create"))
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    "{\"code\":\"CONTABILIDAD\",\"name\":\"Duplicado\",\"roleType\":\"FUNCIONARIO\","
+                        + "\"parentRoleId\":\"01a02a33-4c00-7002-9c4f-5e7ad1000002\"}"))
+        .andExpect(status().isConflict());
+
+    assertThat(((Number) ultima().get("status")).intValue()).isEqualTo(409);
+  }
+
+  private Map<String, Object> ultima() {
+    return jdbc.queryForMap("SELECT * FROM request_log ORDER BY occurred_at DESC, id DESC LIMIT 1");
+  }
+
+  private long cuantas() {
+    return jdbc.queryForObject("SELECT count(*) FROM request_log", Long.class);
+  }
+}

--- a/src/test/java/com/factech/nexus/shared/security/EndpointPermissionsIT.java
+++ b/src/test/java/com/factech/nexus/shared/security/EndpointPermissionsIT.java
@@ -1,0 +1,160 @@
+package com.factech.nexus.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.factech.nexus.IntegrationTestBase;
+import java.lang.reflect.Method;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.method.HandlerMethod;
+import org.springframework.web.servlet.mvc.method.RequestMappingInfo;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+/**
+ * `RNF-SEG-002` — <b>todo endpoint declara su permiso</b> (`security.md` §11, issue #26).
+ *
+ * <p><b>Por qué esta prueba y no la disciplina.</b> La configuración de seguridad deniega por
+ * defecto, de modo que ninguna ruta queda abierta a un anónimo. Pero eso cubre media pregunta: un
+ * endpoint autenticado <b>sin {@code @PreAuthorize}</b> queda accesible a <b>cualquier persona
+ * autenticada</b>, con el rol que sea. Y ese olvido no rompe nada: no falla la compilación, y las
+ * pruebas del propio endpoint se escriben con un actor que tiene permisos, así que pasan.
+ *
+ * <p>`security.md` §11 la describe como <b>«la única forma de garantizar que un endpoint nuevo no
+ * quede expuesto por descuido»</b>. Con cuarenta y un endpoints publicados, es lo que impide que el
+ * cuarenta y dos nazca abierto.
+ *
+ * <p><b>La lista blanca es la parte que importa.</b> No está para hacer pasar la prueba: está para
+ * que añadir un endpoint sin permiso <b>obligue a escribir por qué</b>, en una revisión que alguien
+ * lee, en lugar de que pase inadvertido.
+ */
+class EndpointPermissionsIT extends IntegrationTestBase {
+
+  /**
+   * Endpoints deliberadamente <b>sin</b> exigencia de permiso, y el motivo de cada uno.
+   *
+   * <p>Quien añada una entrada aquí está declarando que ese endpoint es accesible para cualquier
+   * persona autenticada —o para nadie autenticado, si además es público—, y el motivo queda escrito
+   * al lado. Es la diferencia entre una excepción y un olvido.
+   */
+  private static final Map<String, String> SIN_PERMISO_A_PROPOSITO =
+      Map.of(
+          "POST /api/v1/auth/login",
+          "Público por definición: no puede exigirse credencial para obtener una credencial",
+          "POST /api/v1/auth/refresh",
+          "Público por definición: quien renueva no porta todavía un token de acceso válido",
+          "POST /api/v1/auth/logout",
+          "Público a propósito (`RF-SP-036`): exigir token vigente impediría cerrar la sesión"
+              + " justo cuando más falta hace, que es cuando se sospecha que la robaron",
+          "GET /api/v1/users/me",
+          "El actor y solo el actor (`RF-SP-039`): no admite parámetro, de modo que no hay"
+              + " nada que autorizar más allá de estar autenticado",
+          "POST /api/v1/auth/password",
+          "La propia contraseña (`RF-SP-037` §5): «no hay permiso asociado más allá de estar"
+              + " autenticado. Nadie cambia la contraseña de otro por este camino». Cambiar la"
+              + " ajena es `RF-SP-038`, y esa sí exige `users:reset-password`");
+
+  /**
+   * El mapeo de la aplicación, <b>por nombre</b>.
+   *
+   * <p>Actuator registra el suyo —{@code controllerEndpointHandlerMapping}— y sin cualificar hay
+   * dos candidatos del mismo tipo: el contexto no arranca. Se pide el de la aplicación a propósito,
+   * que es el que contiene los endpoints de negocio; los de actuator los gobierna el Art. XV.10 y
+   * no esta regla.
+   */
+  @Autowired
+  @Qualifier("requestMappingHandlerMapping")
+  private RequestMappingHandlerMapping rutas;
+
+  @Test
+  @DisplayName("todo endpoint de /api/v1 declara su permiso, o figura en la lista blanca")
+  void ningunEndpointQuedaExpuestoPorDescuido() {
+    Set<String> sinDeclarar = new TreeSet<>();
+
+    for (Map.Entry<RequestMappingInfo, HandlerMethod> entrada :
+        rutas.getHandlerMethods().entrySet()) {
+
+      for (String firma : firmasDe(entrada.getKey())) {
+        if (!firma.contains("/api/v1")) {
+          // `/actuator/health` lo exige el Art. XV.10 sin autenticación de
+          // negocio, y las rutas de springdoc las gobierna `EXPOSE_API_DOCS`.
+          continue;
+        }
+        if (declaraPermiso(entrada.getValue()) || SIN_PERMISO_A_PROPOSITO.containsKey(firma)) {
+          continue;
+        }
+        sinDeclarar.add(firma);
+      }
+    }
+
+    assertThat(sinDeclarar)
+        .as(
+            "estos endpoints no exigen permiso: cualquier persona autenticada puede ejecutarlos."
+                + " Si es deliberado, decláralo en SIN_PERMISO_A_PROPOSITO con su motivo")
+        .isEmpty();
+  }
+
+  @Test
+  @DisplayName("la lista blanca no se pudre: cada excepción sigue correspondiendo a un endpoint")
+  void laListaBlancaNoConservaFantasmas() {
+    Set<String> existentes = new TreeSet<>();
+    rutas.getHandlerMethods().keySet().forEach(info -> existentes.addAll(firmasDe(info)));
+
+    // Una excepción que sobrevive al endpoint que la justificaba es peor que
+    // inútil: el día que alguien reutilice esa ruta, nacerá abierta y con una
+    // justificación escrita para otra cosa.
+    assertThat(existentes)
+        .as("la lista blanca cita endpoints que ya no existen")
+        .containsAll(SIN_PERMISO_A_PROPOSITO.keySet());
+  }
+
+  @Test
+  @DisplayName("hay al menos cuarenta endpoints: la prueba no pasa por no encontrar ninguno")
+  void laPruebaEstaMirandoAlgo() {
+    long deLaApi =
+        rutas.getHandlerMethods().keySet().stream()
+            .flatMap(info -> firmasDe(info).stream())
+            .filter(firma -> firma.contains("/api/v1"))
+            .count();
+
+    // Sin esto, un cambio que dejara el mapeo vacío haría pasar la prueba en
+    // verde sin haber comprobado nada — que es la forma en que una prueba de
+    // ausencia deja de servir sin avisar.
+    assertThat(deLaApi).isGreaterThanOrEqualTo(40);
+  }
+
+  /**
+   * ¿El manejador exige un permiso?
+   *
+   * <p>Se mira el método y también la clase: {@code @PreAuthorize} sobre el controlador entero es
+   * válido, aunque `security.md` §6 recomienda declararlo por método para que uno añadido más tarde
+   * no herede en silencio un permiso que quizá no le corresponde.
+   */
+  private static boolean declaraPermiso(HandlerMethod manejador) {
+    Method metodo = manejador.getMethod();
+    return metodo.isAnnotationPresent(PreAuthorize.class)
+        || metodo.getDeclaringClass().isAnnotationPresent(PreAuthorize.class);
+  }
+
+  /** Todas las combinaciones de método y ruta de un mapeo, como {@code "GET /api/v1/roles"}. */
+  private static List<String> firmasDe(RequestMappingInfo info) {
+    var metodos = info.getMethodsCondition().getMethods();
+    var patrones = info.getPathPatternsCondition();
+
+    List<String> rutas =
+        patrones == null ? List.of() : patrones.getPatternValues().stream().sorted().toList();
+
+    if (metodos.isEmpty()) {
+      return rutas.stream().map(ruta -> "ANY " + ruta).toList();
+    }
+    return metodos.stream()
+        .flatMap(metodo -> rutas.stream().map(ruta -> metodo.name() + " " + ruta))
+        .toList();
+  }
+}


### PR DESCRIPTION
Promueve a `main` lo mergeado en `develop` por #37.

## Qué llega

- **`request_log` (#23).** La tabla que cinco secciones de `architecture.md` daban por escrita y no existía. Sin ella, lo que el manejador global decide **no** auditar «porque `request_log` ya lo cubre» —los `404`, los `400` de formato, un barrido de rutas— no dejaba rastro en ninguna parte, y los umbrales p95 del Art. XV.9 no se podían medir. Se escribe fuera de la transacción de negocio, envolviendo al límite de tasa, sin cuerpo ni cabeceras.
- **Permisos por endpoint verificados (#26).** `EndpointPermissionsIT` exige que todo manejador bajo `/api/v1` declare `@PreAuthorize` o figure en una lista blanca corta y justificada.

## Pendiente declarado

La purga depende de **D-10**. El valor de configuración existe y **hoy no lo lee nadie**, y así queda escrito donde se declara.

## Verificación

143 unitarias y 535 de integración en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Drxn2fKejvoeLvn47R4J9X