### PR TITLE
fix(config): el correo del superadministrador sale del .env, no de un literal

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,7 +65,16 @@ services:
       # `docker compose ps` fallaban sin que nada estuviera mal.
       #
       # El hash lleva los `$` DUPLICADOS en el `.env`. Ver `.env.example`.
-      SUPERADMIN_EMAIL: "superadmin@factech.co"
+      #
+      # El correo sale del `.env` como todo lo demas. Tenerlo fijo aqui hacia
+      # que `SUPERADMIN_EMAIL` estuviera declarada en el `.env` y NO SE USARA:
+      # se ponia un correo y la base sembraba otro, sin que nada avisara.
+      #
+      # OJO: `V22` ya corrio en las bases existentes y Flyway no repite las
+      # migraciones aplicadas, de modo que cambiar esto NO actualiza el correo
+      # de un superadministrador ya sembrado. Para eso hay que recrear el
+      # volumen de la base o cambiarlo por la API.
+      SUPERADMIN_EMAIL: "${SUPERADMIN_EMAIL}"
       SUPERADMIN_PASSWORD_HASH: ${SUPERADMIN_PASSWORD_HASH}
 
       # Canal de envio saliente (RF-SP-040, D-23). Los valores viven en `.env`,


### PR DESCRIPTION
## Qué estaba mal

`docker-compose.yml` fijaba el correo a mano:

```yaml
SUPERADMIN_EMAIL: "superadmin@factech.co"     # literal
SUPERADMIN_PASSWORD_HASH: ${SUPERADMIN_PASSWORD_HASH}   # interpolada
```

Todas las variables de alrededor se interpolan desde el `.env`; esta no. El efecto es el peor posible para una variable de configuración: **estaba declarada en `.env`, en `.env.example` y documentada en el manual de despliegue — y no se usaba.** Quien ponía su correo veía la base sembrada con otro distinto, y nada lo avisaba.

Es exactamente lo que el issue #30 llama *«una variable declarada que nadie lee es una promesa incumplida»*, aunque aquí no es que nadie la leyera: es que se leía y se pisaba.

## Cómo se detectó

Mirando la base local: el superadministrador tenía el correo de factech y no el declarado en el `.env`. La auditoría de `V22` lo confirma — la fila **nació** con el literal:

```
occurred_at          | action | email
2026-08-31 17:11:52  | CREATE | superadmin@factech.co
```

Y el contenedor lo corroboraba:

```
$ docker exec nexus-app env | grep SUPERADMIN_EMAIL
SUPERADMIN_EMAIL=superadmin@factech.co
```

## Lo que este cambio NO hace, y queda anotado en el propio archivo

**No actualiza el correo de un superadministrador ya sembrado.** `V22` es una migración, ya corrió en las bases existentes, y Flyway no repite las aplicadas: el `INSERT` se ejecutó una vez. Para que un `.env` nuevo tenga efecto hay que **recrear el volumen** de la base o cambiar el correo por la API.

Se deja escrito junto a la variable para que quien despliegue no espere un efecto que no va a ocurrir.

## Por qué en su propio PR

Toca la misma zona de `docker-compose.yml` que el **#51**, pero es otro tema —el correo del superadministrador, no el canal de envío— y se revisa por separado. Si se fusiona antes o después del #51, el conflicto sería trivial: son líneas distintas del mismo bloque.

## Verificación

`docker compose config -q` valida el archivo. El comportamiento se comprobó levantando el entorno: el contenedor recibe ya el valor del `.env`.

No cierra ningún issue. Roza el **#30** —`ENVIRONMENT` y las variables por entorno— pero no lo resuelve: aquel pide decidir los perfiles y los valores de `TRUSTED_PROXIES` y `CORS_ALLOWED_ORIGINS`, que dependen de D-09.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AzFY3JisAP8iUdZZR7qtz
